### PR TITLE
Add LLM response caching layer with Supabase persistence

### DIFF
--- a/src/lib/llm-cache.ts
+++ b/src/lib/llm-cache.ts
@@ -1,0 +1,85 @@
+import { createAdminClient } from "./supabase";
+import type { ChatMessage } from "./openrouter";
+
+interface CacheEntry {
+  cache_key: string;
+  response: string;
+  model: string;
+  created_at: string;
+}
+
+/**
+ * Generate a SHA-256 hash of the request parameters to use as cache key.
+ * Uses Web Crypto API (available in Edge runtime).
+ */
+async function generateCacheKey(
+  messages: ChatMessage[],
+  model: string,
+  maxTokens: number,
+  temperature: number
+): Promise<string> {
+  const payload = JSON.stringify({ messages, model, maxTokens, temperature });
+  const encoded = new TextEncoder().encode(payload);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoded);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Look up a cached LLM response by request parameters.
+ */
+export async function getCachedResponse(
+  messages: ChatMessage[],
+  model: string,
+  maxTokens: number,
+  temperature: number
+): Promise<string | null> {
+  try {
+    const cacheKey = await generateCacheKey(messages, model, maxTokens, temperature);
+    const supabase = createAdminClient();
+
+    const { data, error } = await supabase
+      .from("llm_cache")
+      .select("response")
+      .eq("cache_key", cacheKey)
+      .limit(1)
+      .single();
+
+    if (error || !data) {
+      return null;
+    }
+
+    return (data as CacheEntry).response;
+  } catch {
+    // Cache miss or error — just return null and let the caller make a fresh request
+    return null;
+  }
+}
+
+/**
+ * Store an LLM response in the persistent cache.
+ */
+export async function setCachedResponse(
+  messages: ChatMessage[],
+  model: string,
+  maxTokens: number,
+  temperature: number,
+  response: string
+): Promise<void> {
+  try {
+    const cacheKey = await generateCacheKey(messages, model, maxTokens, temperature);
+    const supabase = createAdminClient();
+
+    await supabase.from("llm_cache").upsert(
+      {
+        cache_key: cacheKey,
+        request_body: JSON.stringify({ messages, model, maxTokens, temperature }),
+        response,
+      },
+      { onConflict: "cache_key" }
+    );
+  } catch {
+    // Silently fail — caching is best-effort
+    console.error("Failed to write LLM cache entry");
+  }
+}

--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -1,4 +1,7 @@
+import { getCachedResponse, setCachedResponse } from "./llm-cache";
+
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
+const MODEL = "google/gemini-3-flash-preview";
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -10,8 +13,20 @@ export async function callOpenRouter(
   options?: {
     maxTokens?: number;
     temperature?: number;
+    skipCache?: boolean;
   }
 ): Promise<string> {
+  const maxTokens = options?.maxTokens ?? 1024;
+  const temperature = options?.temperature ?? 0.7;
+
+  // Check cache first (unless explicitly skipped)
+  if (!options?.skipCache) {
+    const cached = await getCachedResponse(messages, MODEL, maxTokens, temperature);
+    if (cached !== null) {
+      return cached;
+    }
+  }
+
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey) {
     throw new Error("OPENROUTER_API_KEY is not set");
@@ -26,10 +41,10 @@ export async function callOpenRouter(
       "X-Title": "市民意識調査 / Citizen Survey",
     },
     body: JSON.stringify({
-      model: "google/gemini-3-flash-preview",
+      model: MODEL,
       messages,
-      max_tokens: options?.maxTokens ?? 1024,
-      temperature: options?.temperature ?? 0.7,
+      max_tokens: maxTokens,
+      temperature,
     }),
   });
 
@@ -39,12 +54,19 @@ export async function callOpenRouter(
   }
 
   const data = await response.json();
-  return data.choices?.[0]?.message?.content ?? "";
+  const content = data.choices?.[0]?.message?.content ?? "";
+
+  // Store in cache (fire-and-forget)
+  if (!options?.skipCache) {
+    setCachedResponse(messages, MODEL, maxTokens, temperature, content).catch(() => {});
+  }
+
+  return content;
 }
 
 // Model info for transparency page
 export const MODEL_INFO = {
-  id: "google/gemini-3-flash-preview",
+  id: MODEL,
   name: "Gemini 3 Flash Preview",
   provider: "Google (via OpenRouter)",
   description:

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -81,3 +81,24 @@ CREATE TRIGGER update_responses_updated_at
   BEFORE UPDATE ON responses
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================
+-- LLM response cache table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS llm_cache (
+  cache_key TEXT PRIMARY KEY,
+  request_body JSONB NOT NULL,
+  response TEXT NOT NULL,
+  model TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index for cleanup queries (e.g. delete old entries)
+CREATE INDEX IF NOT EXISTS idx_llm_cache_created_at ON llm_cache(created_at);
+
+-- RLS: Only service role can access cache
+ALTER TABLE llm_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access to llm_cache" ON llm_cache
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
This PR introduces a persistent caching layer for LLM responses to reduce API calls and improve performance. Responses are cached based on a SHA-256 hash of request parameters (messages, model, max tokens, temperature) and stored in a new Supabase table.

## Key Changes
- **New `llm-cache.ts` module**: Implements cache lookup and storage functions
  - `getCachedResponse()`: Retrieves cached responses by generating a cache key from request parameters
  - `setCachedResponse()`: Stores responses in the cache (fire-and-forget, non-blocking)
  - Uses Web Crypto API for SHA-256 hashing (compatible with Edge runtime)

- **Updated `openrouter.ts`**: Integrates caching into the LLM call flow
  - Checks cache before making API requests (unless `skipCache` option is set)
  - Stores successful responses in cache after API calls
  - Extracts model name to a constant for consistency
  - Normalizes `maxTokens` and `temperature` defaults before cache operations

- **New database schema**: Adds `llm_cache` table with RLS policies
  - `cache_key` (TEXT PRIMARY KEY): SHA-256 hash of request parameters
  - `request_body` (JSONB): Full request parameters for debugging
  - `response` (TEXT): Cached LLM response
  - `created_at` (TIMESTAMPTZ): Timestamp for cleanup/expiration queries
  - Index on `created_at` for efficient cleanup operations
  - RLS policy restricts access to service role only

## Implementation Details
- Cache operations are non-blocking and fail silently to prevent disrupting the main request flow
- The `skipCache` option allows callers to bypass caching when needed (e.g., for fresh responses)
- Cache key generation is deterministic based on all request parameters, ensuring consistent lookups
- Uses Supabase admin client for cache operations (service role access)

https://claude.ai/code/session_01BLr14FDzpReKsKvMkZnDh7