### PR TITLE
管理者ダッシュボード: Q6-Q9のデータ欠落を修正

### DIFF
--- a/src/app/api/admin/route.ts
+++ b/src/app/api/admin/route.ts
@@ -9,6 +9,7 @@ function checkAuth(req: NextRequest): boolean {
 }
 
 interface AnswerRow {
+  session_id: string;
   question_id: string;
   question_text: string | null;
   likert: string | null;
@@ -39,18 +40,28 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  // Fetch all answers
-  const { data: allAnswers, error: answersError } = await supabase
-    .from("answers")
-    .select("*")
-    .order("question_id");
+  // PostgREST silently caps a single select at its max-rows setting. With
+  // .order("question_id") (string sort), q6-q9 sort last and were the first
+  // to get dropped once total answers grew past the cap.
+  const allAnswers: AnswerRow[] = [];
+  const PAGE_SIZE = 1000;
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data: page, error: answersError } = await supabase
+      .from("answers")
+      .select("*")
+      .range(from, from + PAGE_SIZE - 1);
 
-  if (answersError) {
-    console.error("Admin answers fetch error:", answersError);
-    return NextResponse.json(
-      { error: "データの取得に失敗しました。" },
-      { status: 500 },
-    );
+    if (answersError) {
+      console.error("Admin answers fetch error:", answersError);
+      return NextResponse.json(
+        { error: "データの取得に失敗しました。" },
+        { status: 500 },
+      );
+    }
+
+    if (!page || page.length === 0) break;
+    allAnswers.push(...(page as AnswerRow[]));
+    if (page.length < PAGE_SIZE) break;
   }
 
   // Group answers by session_id


### PR DESCRIPTION
## Summary
- 管理者ダッシュボードおよびCSVダウンロードでQ6-Q9のデータが欠落していた問題を修正
- 原因: `/api/admin` の `answers` 一括取得が PostgREST の行数上限で切り捨てられ、`question_id` の文字列ソート（`q1, q10..q18, q2..q9`）で末尾に並ぶ q6-q9 が真っ先に消えていた
- 修正: `.range()` で1000件ずつページングし全件取得するように変更

## Test plan
- [ ] `/admin` にログインし、Q1-Q13 詳細タブでQ6-Q9に回答分布・自由記述が表示されることを確認
- [ ] 個別回答タブで各セッションのQ6-Q9セルが`—`ではなく実データになっていることを確認
- [ ] CSVダウンロードを行い、`q6_*`〜`q9_*` カラムに値が入っていることを確認
- [ ] 回答総数が1000件未満の環境でも従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)