### PR TITLE
クラスター分析パイプラインを実装 (Issue #25, #26, #27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,15 @@
     "lint": "next lint",
     "check": "biome check --write",
     "format": "biome format --write",
-    "wrangler": "wrangler"
+    "wrangler": "wrangler",
+    "seed:cluster": "node --env-file=.env.development.local --import tsx scripts/seed-cluster-test-data.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",
+    "ml-distance": "^4.0.1",
+    "ml-kmeans": "^7.0.0",
+    "ml-matrix": "^6.12.2",
+    "ml-pca": "^4.1.1",
     "next": "^15.5.14",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -32,6 +37,7 @@
     "eslint-config-next": "^15.3.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^4.0.0",
+    "tsx": "^4.22.0",
     "typescript": "^5.6.0",
     "wrangler": "^4.80.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.45.0
         version: 2.101.1
+      ml-distance:
+        specifier: ^4.0.1
+        version: 4.0.1
+      ml-kmeans:
+        specifier: ^7.0.0
+        version: 7.0.0
+      ml-matrix:
+        specifier: ^6.12.2
+        version: 6.12.2
+      ml-pca:
+        specifier: ^4.1.1
+        version: 4.1.1
       next:
         specifier: ^15.5.14
         version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -57,6 +69,9 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2
+      tsx:
+        specifier: ^4.22.0
+        version: 4.22.0
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
@@ -454,6 +469,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.4':
     resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
     engines: {node: '>=18'}
@@ -462,6 +483,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -478,6 +505,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.4':
     resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
     engines: {node: '>=18'}
@@ -486,6 +519,12 @@ packages:
 
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -502,6 +541,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.4':
     resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
     engines: {node: '>=18'}
@@ -510,6 +555,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -526,6 +577,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.4':
     resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
     engines: {node: '>=18'}
@@ -534,6 +591,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -550,6 +613,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.4':
     resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
     engines: {node: '>=18'}
@@ -558,6 +627,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -574,6 +649,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.4':
     resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
     engines: {node: '>=18'}
@@ -582,6 +663,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -598,6 +685,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.4':
     resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
     engines: {node: '>=18'}
@@ -606,6 +699,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -622,6 +721,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.4':
     resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
     engines: {node: '>=18'}
@@ -630,6 +735,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -646,6 +757,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.4':
     resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
     engines: {node: '>=18'}
@@ -654,6 +771,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -670,6 +793,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.4':
     resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
     engines: {node: '>=18'}
@@ -678,6 +807,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -694,8 +829,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -712,6 +859,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.4':
     resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
     engines: {node: '>=18'}
@@ -720,6 +873,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -736,6 +895,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.4':
     resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
     engines: {node: '>=18'}
@@ -744,6 +909,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1738,6 +1909,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  binary-search@1.3.6:
+    resolution: {integrity: sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
@@ -1995,6 +2169,11 @@ packages:
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2391,6 +2570,12 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-any-array@2.0.1:
+    resolution: {integrity: sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==}
+
+  is-any-array@3.0.0:
+    resolution: {integrity: sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww==}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -2731,6 +2916,51 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  ml-array-max@2.0.0:
+    resolution: {integrity: sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==}
+
+  ml-array-mean@1.1.6:
+    resolution: {integrity: sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==}
+
+  ml-array-min@2.0.0:
+    resolution: {integrity: sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg==}
+
+  ml-array-rescale@2.0.0:
+    resolution: {integrity: sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg==}
+
+  ml-array-sum@1.1.6:
+    resolution: {integrity: sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==}
+
+  ml-distance-euclidean@2.0.0:
+    resolution: {integrity: sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==}
+
+  ml-distance-euclidean@3.0.1:
+    resolution: {integrity: sha512-jEEu/1a73ArPmIiwOzrcah6TfhtV19dCKnnM7JvdR2xTzyVJFGgIIR78Vg8Pl9z2NVeSRoFOpzc0910sPMINsA==}
+
+  ml-distance@4.0.1:
+    resolution: {integrity: sha512-feZ5ziXs01zhyFUUUeZV5hwc0f5JW0Sh0ckU1koZe/wdVkJdGxcP06KNQuF0WBTj8FttQUzcvQcpcrOp/XrlEw==}
+
+  ml-kmeans@7.0.0:
+    resolution: {integrity: sha512-Ud8x4YMURVgupAcuSxD9iwc/us4mqyryFnx08gjEGfAyP1iWlJSdBADD96PlpkpHUvRVDNEmk28euGQJZeuU7A==}
+
+  ml-matrix@6.12.2:
+    resolution: {integrity: sha512-GC+BnW+pBh8Auap8goAxY0senAmF0IEoc3HNVSfnfbvGw0buuDIYb9kAKMS1l+GiwJ1rfK2bzJ8IHhwjzATSFA==}
+
+  ml-nearest-vector@3.0.1:
+    resolution: {integrity: sha512-7UQ60sPS1Dpe6N6zuEsaL3nrUGHkaiSmjWcQHfMYFfV1dgp6TiPtv3ZtdLHwpf1jS0KQDSkw9pycJO1gYBiEoA==}
+
+  ml-pca@4.1.1:
+    resolution: {integrity: sha512-HQwswMK1dObj+ppk3EPcQMR2djWK0Cri8mAFd2nITtXHkLfO4DBBsEtiCT5KiR+2e3hQjp+lI0UyqZpdf04AlQ==}
+
+  ml-random@2.0.0:
+    resolution: {integrity: sha512-/ziHm0qyvsvwRy0y+EhmhTKbvq+9ghqf9UYSexKeyx8pp+9avDBLctYaopdTaJ1HU4qnJPEy7XH0CVeh9tHIgQ==}
+
+  ml-tree-similarity@1.0.0:
+    resolution: {integrity: sha512-XJUyYqjSuUQkNQHMscr6tcjldsOoAekxADTplt40QKfwW6nd++1wHWV9AArl0Zvw/TIHgNaZZNvr8QGvE8wLRg==}
+
+  ml-xsadd@3.0.1:
+    resolution: {integrity: sha512-Fz2q6dwgzGM8wYKGArTUTZDGa4lQFA2Vi6orjGeTVRy22ZnQFKlJuwS9n8NRviqz1KHAHAzdKJwbnYhdo38uYg==}
+
   mnemonist@0.38.3:
     resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
 
@@ -2795,6 +3025,10 @@ packages:
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  num-sort@2.1.0:
+    resolution: {integrity: sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==}
     engines: {node: '>=8'}
 
   object-assign@4.1.1:
@@ -3225,6 +3459,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.0:
+    resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4221,10 +4460,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.25.4':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.25.4':
@@ -4233,10 +4478,16 @@ snapshots:
   '@esbuild/android-arm@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.25.4':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.4':
@@ -4245,10 +4496,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.4':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.4':
@@ -4257,10 +4514,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.25.4':
@@ -4269,10 +4532,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.25.4':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.25.4':
@@ -4281,10 +4550,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.4':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.4':
@@ -4293,10 +4568,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.4':
@@ -4305,10 +4586,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.25.4':
@@ -4317,10 +4604,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.4':
@@ -4329,10 +4622,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.4':
@@ -4341,7 +4640,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.4':
@@ -4350,10 +4655,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.4':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.25.4':
@@ -4362,10 +4673,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.25.4':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -5454,6 +5771,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  binary-search@1.3.6: {}
+
   blake3-wasm@2.1.5: {}
 
   body-parser@2.2.2:
@@ -5827,6 +6146,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -6330,6 +6678,10 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-any-array@2.0.1: {}
+
+  is-any-array@3.0.0: {}
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -6635,6 +6987,69 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  ml-array-max@2.0.0:
+    dependencies:
+      is-any-array: 3.0.0
+
+  ml-array-mean@1.1.6:
+    dependencies:
+      ml-array-sum: 1.1.6
+
+  ml-array-min@2.0.0:
+    dependencies:
+      is-any-array: 3.0.0
+
+  ml-array-rescale@2.0.0:
+    dependencies:
+      is-any-array: 3.0.0
+      ml-array-max: 2.0.0
+      ml-array-min: 2.0.0
+
+  ml-array-sum@1.1.6:
+    dependencies:
+      is-any-array: 2.0.1
+
+  ml-distance-euclidean@2.0.0: {}
+
+  ml-distance-euclidean@3.0.1: {}
+
+  ml-distance@4.0.1:
+    dependencies:
+      ml-array-mean: 1.1.6
+      ml-distance-euclidean: 2.0.0
+      ml-tree-similarity: 1.0.0
+
+  ml-kmeans@7.0.0:
+    dependencies:
+      ml-distance-euclidean: 3.0.1
+      ml-matrix: 6.12.2
+      ml-nearest-vector: 3.0.1
+      ml-random: 2.0.0
+
+  ml-matrix@6.12.2:
+    dependencies:
+      is-any-array: 3.0.0
+      ml-array-rescale: 2.0.0
+
+  ml-nearest-vector@3.0.1:
+    dependencies:
+      ml-distance-euclidean: 3.0.1
+
+  ml-pca@4.1.1:
+    dependencies:
+      ml-matrix: 6.12.2
+
+  ml-random@2.0.0:
+    dependencies:
+      ml-xsadd: 3.0.1
+
+  ml-tree-similarity@1.0.0:
+    dependencies:
+      binary-search: 1.3.6
+      num-sort: 2.1.0
+
+  ml-xsadd@3.0.1: {}
+
   mnemonist@0.38.3:
     dependencies:
       obliterator: 1.6.1
@@ -6688,6 +7103,8 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  num-sort@2.1.0: {}
 
   object-assign@4.1.1: {}
 
@@ -7196,6 +7613,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.22.0:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/seed-cluster-test-data.ts
+++ b/scripts/seed-cluster-test-data.ts
@@ -1,0 +1,391 @@
+// ============================================================
+// クラスタリング動作確認用のテストデータ投入スクリプト
+// 30人ぶんの page_completed=2 セッション + Q1-Q13 + フォローアップ5問を生成
+//
+// 使い方:
+//   pnpm seed:cluster
+// 内部的には:
+//   node --env-file=.env.development.local --import tsx scripts/seed-cluster-test-data.ts
+//
+// 冪等: user_agent='seed-script/...' のセッションを事前削除してから投入
+//
+// ペルソナ (4方向に尖らせて K=4 が見えやすいよう設計):
+//   A: 規制強化派 (n=8)        — 企業も政府も強く規制すべき
+//   B: 自由・個人責任派 (n=8)  — 教育で対処、企業義務・政府介入は反対
+//   C: 折衷・教育推進派 (n=8)  — 教育を軸に、規制は穏当に、政府介入も支持
+//   D: 政府不信・自主規制派 (n=6) — 企業の自主規制はOKだが政府介入は強く反対
+//
+// 各セッションに固定5問のフォローアップ (q14-q18) を付与。
+// フォローアップの質問文はペルソナごとの「LLM生成相当」プールから抽選。
+// ============================================================
+
+import { randomUUID } from "node:crypto";
+import { createClient } from "@supabase/supabase-js";
+import type { LikertValue } from "../src/lib/survey-data";
+import { SURVEY_QUESTIONS } from "../src/lib/survey-data";
+import type { Database } from "../src/lib/database.types";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_ROLE) {
+  console.error(
+    "NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY が未設定です。\n" +
+      "  node --env-file=.env.development.local --import tsx scripts/seed-cluster-test-data.ts",
+  );
+  process.exit(1);
+}
+
+const supabase = createClient<Database>(SUPABASE_URL, SERVICE_ROLE);
+
+const QUESTION_IDS = SURVEY_QUESTIONS.map((q) => q.id);
+const QUESTION_TEXT_BY_ID: Record<string, string> = Object.fromEntries(
+  SURVEY_QUESTIONS.map((q) => [q.id, q.text]),
+);
+
+// リッカート選択肢ごとの重み配列
+// [strongly_agree, agree, neutral, disagree, strongly_disagree, dont_know]
+type WeightVector = readonly [number, number, number, number, number, number];
+
+const W_VERY_PRO: WeightVector = [0.65, 0.3, 0.04, 0.01, 0.0, 0.0];
+const W_VERY_CON: WeightVector = [0.0, 0.01, 0.04, 0.3, 0.65, 0.0];
+const W_STRONG_PRO: WeightVector = [0.4, 0.45, 0.1, 0.04, 0.0, 0.01];
+const W_STRONG_CON: WeightVector = [0.0, 0.04, 0.1, 0.45, 0.4, 0.01];
+const W_MILD_PRO: WeightVector = [0.2, 0.5, 0.2, 0.08, 0.0, 0.02];
+const W_MILD_CON: WeightVector = [0.0, 0.08, 0.2, 0.5, 0.2, 0.02];
+const W_NEUTRAL: WeightVector = [0.05, 0.15, 0.55, 0.15, 0.05, 0.05];
+
+const LIKERT_BY_INDEX: LikertValue[] = [
+  "strongly_agree",
+  "agree",
+  "neutral",
+  "disagree",
+  "strongly_disagree",
+  "dont_know",
+];
+
+interface Persona {
+  n: number;
+  weights: Record<string, WeightVector>;
+  freetexts: Partial<Record<string, string[]>>;
+  /** フォローアップ質問プール: AIが生成しそうな質問文を集めておき、5問ランダム抽選 */
+  followupQuestionPool: string[];
+  /** フォローアップ回答時のLikert重み (1つの分布で全フォローアップに適用) */
+  followupWeights: WeightVector;
+  /** フォローアップ用 freetext プール */
+  followupFreetextPool: string[];
+}
+
+const PERSONAS: Record<string, Persona> = {
+  A: {
+    n: 8,
+    weights: {
+      q1: W_STRONG_PRO,
+      q2: W_VERY_PRO,
+      q3: W_NEUTRAL,
+      q4: W_VERY_PRO,
+      q5: W_VERY_PRO,
+      q6: W_VERY_PRO,
+      q7: W_VERY_PRO,
+      q8: W_VERY_CON,
+      q9: W_VERY_PRO,
+      q10: W_VERY_PRO,
+      q11: W_VERY_CON,
+      q12: W_VERY_PRO,
+      q13: W_VERY_PRO,
+    },
+    freetexts: {
+      q2: ["詐欺の巧妙化に個人では限界がある", "社会全体で防ぐ仕組みが必要"],
+      q6: [
+        "広告で利益を得る企業は迅速対応が責務",
+        "拡散の速さを考えると24時間以内必須",
+      ],
+      q11: [
+        "詐欺は犯罪。規制は自由の侵害ではない",
+        "被害者保護のための公正なルール",
+      ],
+    },
+    followupQuestionPool: [
+      "国際的に統一された詐欺広告規制の枠組みを日本が主導すべきだと思いますか？",
+      "違反事業者の役員にも個人責任を問う制度が必要だと思いますか？",
+      "詐欺広告の被害者に対する公的補償制度を国が設けるべきだと思いますか？",
+      "削除義務に違反した広告プラットフォームに対し、課徴金を売上の数%として課すべきだと思いますか？",
+      "公的な広告主データベースに本人確認情報を登録することを義務化すべきだと思いますか？",
+      "規制違反企業の役員に対し、一定期間の業界活動を禁止する制裁が必要だと思いますか？",
+      "プラットフォームの広告審査プロセスを第三者監査の対象にすべきだと思いますか？",
+    ],
+    followupWeights: W_STRONG_PRO,
+    followupFreetextPool: [
+      "迅速で実効的な対応のためには強い罰則が必要だと考える。",
+      "被害者保護を最優先にすべきで、企業側の負担はやむを得ない。",
+      "他国の先行事例を参考に、日本も毅然と取り組むべき。",
+    ],
+  },
+  B: {
+    n: 8,
+    weights: {
+      q1: W_NEUTRAL,
+      q2: W_MILD_CON,
+      q3: W_VERY_PRO,
+      q4: W_VERY_CON,
+      q5: W_STRONG_CON,
+      q6: W_STRONG_CON,
+      q7: W_VERY_CON,
+      q8: W_VERY_PRO,
+      q9: W_VERY_CON,
+      q10: W_VERY_CON,
+      q11: W_VERY_PRO,
+      q12: W_VERY_CON,
+      q13: W_VERY_CON,
+    },
+    freetexts: {
+      q3: [
+        "個人のリテラシーを上げることが本質的な解決",
+        "教育で対処すべき領域",
+      ],
+      q8: [
+        "民間の柔軟性を活かす方が効率的",
+        "技術変化が速いので自主規制が現実的",
+      ],
+      q11: ["過度な規制は表現の自由を損なう", "創意工夫が阻害される懸念"],
+      q13: ["数値目標は副作用を生む", "柔軟な対応が現実的"],
+    },
+    followupQuestionPool: [
+      "規制よりもプラットフォーム間の競争による品質向上のほうが効果的だと思いますか？",
+      "AI技術の進化を阻害しない範囲で対策を進めるべきだと思いますか？",
+      "ユーザー側のオプトアウト機能を充実させる方が、削除義務化より望ましいと思いますか？",
+      "規制の対象を中小事業者にまで広げると、新規参入の障害になると思いますか？",
+      "海外プラットフォームに国内法を強制適用しても実効性は乏しいと思いますか？",
+      "規制の運用は時の政権の意向に左右されるリスクが高いと思いますか？",
+      "民間の認証制度を充実させることで、政府介入を最小化すべきだと思いますか？",
+    ],
+    followupWeights: W_MILD_PRO,
+    followupFreetextPool: [
+      "規制よりも市場の自浄作用に期待したい。",
+      "技術革新の自由度を守ることが長期的には消費者の利益にもなる。",
+      "国境を越える広告に国内法を当てはめても限界がある。",
+    ],
+  },
+  C: {
+    n: 8,
+    weights: {
+      q1: W_STRONG_PRO,
+      q2: W_STRONG_PRO,
+      q3: W_VERY_PRO,
+      q4: W_MILD_PRO,
+      q5: W_STRONG_PRO,
+      q6: W_MILD_PRO,
+      q7: W_NEUTRAL,
+      q8: W_STRONG_PRO,
+      q9: W_NEUTRAL,
+      q10: W_NEUTRAL,
+      q11: W_NEUTRAL,
+      q12: W_STRONG_PRO,
+      q13: W_NEUTRAL,
+    },
+    freetexts: {
+      q3: [
+        "詐欺を見抜く力を養う教育が最重要",
+        "規制だけでは限界、判断力が鍵",
+      ],
+      q5: [
+        "ラベルの意味を理解する教育が必要",
+        "情報リテラシーがあって初めて機能する",
+      ],
+      q8: [
+        "企業の自主的な改善と教育を組み合わせるのが現実的",
+      ],
+    },
+    followupQuestionPool: [
+      "学校教育の中に情報リテラシーの専門科目を設けるべきだと思いますか？",
+      "高齢者向けの詐欺被害防止講座を自治体が定期的に提供すべきだと思いますか？",
+      "プラットフォーム上で詐欺広告の見抜き方を案内するチュートリアル機能が有効だと思いますか？",
+      "詐欺事例をオープンデータとして共有することで国民の警戒心を高められると思いますか？",
+      "金融機関の窓口での教育・声かけが詐欺被害の抑止に有効だと思いますか？",
+      "AIが学習教材として詐欺事例をシミュレーションする取り組みが必要だと思いますか？",
+      "地域コミュニティでの相互啓発が効果的だと思いますか？",
+    ],
+    followupWeights: W_VERY_PRO,
+    followupFreetextPool: [
+      "規制だけでは穴ができるので、人の判断力を上げることが本質的解決になる。",
+      "技術的対策と教育を両輪で進めることが望ましい。",
+      "世代別に必要な教育内容は異なるので、的を絞った設計が必要。",
+    ],
+  },
+  D: {
+    n: 6,
+    weights: {
+      q1: W_NEUTRAL,
+      q2: W_MILD_PRO,
+      q3: W_STRONG_PRO,
+      q4: W_STRONG_PRO,
+      q5: W_STRONG_PRO,
+      q6: W_STRONG_PRO,
+      q7: W_NEUTRAL,
+      q8: W_VERY_PRO,
+      q9: W_VERY_CON,
+      q10: W_MILD_CON,
+      q11: W_STRONG_PRO,
+      q12: W_VERY_CON,
+      q13: W_MILD_CON,
+    },
+    freetexts: {
+      q8: [
+        "企業が自主的に対策する仕組みを成熟させるべき",
+        "民間主導の枠組みが望ましい",
+      ],
+      q9: ["政府の介入はやり過ぎ", "法規制は最終手段にすべき"],
+      q12: [
+        "政府主導のシステムは恣意的運用のリスクがある",
+        "公的システムよりも民間の通報ハブの方が現実的",
+      ],
+    },
+    followupQuestionPool: [
+      "詐欺広告対策の優先順位は他の社会課題と比べて高いと思いますか？",
+      "詐欺被害の統計データを政府が定期公表すべきだと思いますか？",
+      "対策の効果を客観的に測定する仕組みが必要だと思いますか？",
+      "詐欺広告の通報窓口を一本化することは現実的だと思いますか？",
+      "個人情報保護と詐欺対策の両立は可能だと思いますか？",
+      "海外との情報共有がどの程度進めば効果が出ると思いますか？",
+      "詐欺対策に充てる予算規模はどの程度が妥当だと思いますか？",
+    ],
+    followupWeights: W_VERY_CON,
+    followupFreetextPool: [
+      "現状の情報が少なすぎて判断が難しい。",
+      "もう少し具体的な事例が見えれば賛否を決められる気がする。",
+      "専門家の議論をもっと聞いてみたい。",
+    ],
+  },
+};
+
+function pickWeighted(weights: WeightVector): LikertValue {
+  const r = Math.random();
+  let acc = 0;
+  for (let i = 0; i < weights.length; i++) {
+    acc += weights[i];
+    if (r < acc) return LIKERT_BY_INDEX[i];
+  }
+  return LIKERT_BY_INDEX[LIKERT_BY_INDEX.length - 1];
+}
+
+function pickFreetext(persona: Persona, qid: string): string {
+  const choices = persona.freetexts[qid];
+  if (!choices || choices.length === 0) return "";
+  if (Math.random() < 0.3) return "";
+  return choices[Math.floor(Math.random() * choices.length)];
+}
+
+function pickFollowupFreetext(persona: Persona): string {
+  if (Math.random() < 0.2) return "";
+  const pool = persona.followupFreetextPool;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function sampleFollowupQuestions(persona: Persona, count: number): string[] {
+  const pool = [...persona.followupQuestionPool];
+  const picked: string[] = [];
+  for (let i = 0; i < count && pool.length > 0; i++) {
+    const idx = Math.floor(Math.random() * pool.length);
+    picked.push(pool[idx]);
+    pool.splice(idx, 1);
+  }
+  return picked;
+}
+
+const FOLLOWUP_COUNT = 5;
+const FOLLOWUP_ID_START = SURVEY_QUESTIONS.length + 1; // q14
+
+const USER_AGENT_PREFIX = "seed-script/";
+
+async function clearExistingSeeds(): Promise<void> {
+  // user_agent が seed-script/ で始まる sessions を削除（answers は ON DELETE CASCADE で同時に消える）
+  const { data, error } = await supabase
+    .from("sessions")
+    .select("session_id")
+    .like("user_agent", `${USER_AGENT_PREFIX}%`);
+  if (error) throw new Error(`既存seed取得エラー: ${error.message}`);
+  if (!data || data.length === 0) return;
+  console.log(`Clearing ${data.length} existing seed sessions...`);
+  const ids = data.map((r) => r.session_id);
+  const { error: dErr } = await supabase
+    .from("sessions")
+    .delete()
+    .in("session_id", ids);
+  if (dErr) throw new Error(`既存seed削除エラー: ${dErr.message}`);
+}
+
+async function main(): Promise<void> {
+  console.log("Seeding cluster test data...");
+  await clearExistingSeeds();
+
+  const sessions: Database["public"]["Tables"]["sessions"]["Insert"][] = [];
+  const answers: Database["public"]["Tables"]["answers"]["Insert"][] = [];
+
+  for (const [name, persona] of Object.entries(PERSONAS)) {
+    for (let i = 0; i < persona.n; i++) {
+      const sessionId = randomUUID();
+      sessions.push({
+        session_id: sessionId,
+        interest_level: 3 + Math.floor(Math.random() * 2),
+        interest_reasons: ["news_media"],
+        page_completed: 2,
+        user_agent: `${USER_AGENT_PREFIX}persona-${name}`,
+        completed_at: new Date().toISOString(),
+      });
+      for (const qid of QUESTION_IDS) {
+        const weights = persona.weights[qid];
+        if (!weights) continue;
+        answers.push({
+          session_id: sessionId,
+          question_id: qid,
+          question_text: QUESTION_TEXT_BY_ID[qid] ?? "",
+          likert: pickWeighted(weights),
+          freetext: pickFreetext(persona, qid),
+          is_followup: false,
+        });
+      }
+
+      // フォローアップ5問
+      const followupQuestions = sampleFollowupQuestions(persona, FOLLOWUP_COUNT);
+      for (let f = 0; f < followupQuestions.length; f++) {
+        const qid = `q${FOLLOWUP_ID_START + f}`;
+        answers.push({
+          session_id: sessionId,
+          question_id: qid,
+          question_text: followupQuestions[f],
+          likert: pickWeighted(persona.followupWeights),
+          freetext: pickFollowupFreetext(persona),
+          is_followup: true,
+        });
+      }
+    }
+  }
+
+  console.log(
+    `Inserting ${sessions.length} sessions, ${answers.length} answers...`,
+  );
+
+  const { error: sErr } = await supabase.from("sessions").insert(sessions);
+  if (sErr) throw new Error(`sessions insert failed: ${sErr.message}`);
+
+  const CHUNK = 200;
+  for (let i = 0; i < answers.length; i += CHUNK) {
+    const slice = answers.slice(i, i + CHUNK);
+    const { error: aErr } = await supabase.from("answers").insert(slice);
+    if (aErr) {
+      throw new Error(
+        `answers insert failed at offset ${i}: ${aErr.message}`,
+      );
+    }
+  }
+
+  console.log(`✅ Done. ${sessions.length} sessions seeded.`);
+  console.log(
+    "Run /admin → クラスター分析タブ → 「再計算」 to test the pipeline.",
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/admin/ClusterAnalysisTab.tsx
+++ b/src/app/admin/ClusterAnalysisTab.tsx
@@ -1,0 +1,660 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { SURVEY_QUESTIONS } from "@/lib/survey-data";
+
+const CLUSTER_COLORS = [
+  "#e74c3c",
+  "#2ecc71",
+  "#f39c12",
+  "#8e6f47",
+  "#9b59b6",
+  "#3498db",
+];
+
+interface ClusterRun {
+  id: string;
+  calculated_at: string | null;
+  n_respondents: number;
+  n_questions: number;
+  k_chosen: number;
+  silhouette_score: number | null;
+  pca_explained_variance: number[];
+  pca_loadings: Record<string, { pc1: number; pc2: number }>;
+  axis_labels: {
+    pc1?: { positive?: string; negative?: string };
+    pc2?: { positive?: string; negative?: string };
+  } | null;
+  silhouette_by_k: Record<string, number> | null;
+  question_ids: string[];
+  reasons_built_at: string | null;
+}
+
+interface Assignment {
+  session_id: string;
+  cluster_id: number;
+  pc1: number;
+  pc2: number;
+}
+
+interface Summary {
+  cluster_id: number;
+  question_id: string;
+  summary: string;
+  diversity_score: number | null;
+  n_texts: number;
+  mean_in: number | null;
+  mean_out: number | null;
+  diff: number | null;
+  representativeness: number | null;
+}
+
+interface Insight {
+  question_id: string;
+  insight_text: string;
+  dominant_axis: "pc1" | "pc2" | null;
+  disagreement_std: number | null;
+}
+
+interface LatestPayload {
+  run: ClusterRun | null;
+  assignments: Assignment[];
+  summaries: Summary[];
+  insights: Insight[];
+}
+
+const QUESTION_TEXTS: Record<string, string> = (() => {
+  const out: Record<string, string> = {};
+  for (const q of SURVEY_QUESTIONS) out[q.id] = q.text;
+  return out;
+})();
+
+function questionOrder(qid: string): number {
+  return Number.parseInt(qid.replace(/\D/g, ""), 10) || 0;
+}
+
+export function ClusterAnalysisTab({ password }: { password: string }) {
+  const [payload, setPayload] = useState<LatestPayload | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRecomputing, setIsRecomputing] = useState(false);
+  const [isBuildingReasons, setIsBuildingReasons] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedQuestion, setSelectedQuestion] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<"default" | "high" | "low">("default");
+
+  const fetchLatest = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/cluster/latest", {
+        headers: { Authorization: `Bearer ${password}` },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as LatestPayload;
+      setPayload(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [password]);
+
+  useEffect(() => {
+    fetchLatest();
+  }, [fetchLatest]);
+
+  const handleRecompute = async () => {
+    setIsRecomputing(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/cluster/recompute", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${password}` },
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      await fetchLatest();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsRecomputing(false);
+    }
+  };
+
+  const handleBuildReasons = async () => {
+    setIsBuildingReasons(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/cluster/build-reasons", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${password}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      await fetchLatest();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsBuildingReasons(false);
+    }
+  };
+
+  const handleDownloadJson = () => {
+    if (!payload) return;
+    const ts =
+      payload.run?.calculated_at?.replace(/[:.]/g, "-").slice(0, 19) ||
+      new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `cluster-analysis-${ts}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const run = payload?.run ?? null;
+  const assignments = payload?.assignments ?? [];
+  const summaries = payload?.summaries ?? [];
+  const insights = payload?.insights ?? [];
+
+  const clusterSizes = useMemo(() => {
+    const out = new Map<number, number>();
+    for (const a of assignments)
+      out.set(a.cluster_id, (out.get(a.cluster_id) ?? 0) + 1);
+    return out;
+  }, [assignments]);
+
+  const clusterIds = useMemo(
+    () => [...clusterSizes.keys()].sort((a, b) => a - b),
+    [clusterSizes],
+  );
+
+  const questionList = useMemo(() => {
+    const qids = run?.question_ids ?? [
+      ...new Set(summaries.map((s) => s.question_id)),
+    ];
+    const items = qids.map((qid) => {
+      const ins = insights.find((i) => i.question_id === qid);
+      return {
+        qid,
+        disagreement: ins?.disagreement_std ?? null,
+      };
+    });
+    if (sortBy === "high") {
+      items.sort(
+        (a, b) => (b.disagreement ?? -Infinity) - (a.disagreement ?? -Infinity),
+      );
+    } else if (sortBy === "low") {
+      items.sort(
+        (a, b) => (a.disagreement ?? Infinity) - (b.disagreement ?? Infinity),
+      );
+    } else {
+      items.sort((a, b) => questionOrder(a.qid) - questionOrder(b.qid));
+    }
+    return items;
+  }, [run, summaries, insights, sortBy]);
+
+  const selectedInsight = useMemo(
+    () =>
+      selectedQuestion
+        ? insights.find((i) => i.question_id === selectedQuestion)
+        : undefined,
+    [insights, selectedQuestion],
+  );
+
+  const selectedSummaries = useMemo(() => {
+    if (!selectedQuestion) return [];
+    return summaries
+      .filter((s) => s.question_id === selectedQuestion)
+      .sort((a, b) => a.cluster_id - b.cluster_id);
+  }, [summaries, selectedQuestion]);
+
+  const polarityGroups = useMemo(() => {
+    if (!selectedQuestion || !selectedInsight)
+      return { positive: [], negative: [] };
+    const axis = selectedInsight.dominant_axis ?? "pc1";
+    const clusterCoords = new Map<number, { pc1: number; pc2: number }>();
+    for (const a of assignments) {
+      if (!clusterCoords.has(a.cluster_id)) {
+        clusterCoords.set(a.cluster_id, { pc1: 0, pc2: 0 });
+      }
+    }
+    // クラスタ重心
+    const accum = new Map<number, { pc1: number; pc2: number; n: number }>();
+    for (const a of assignments) {
+      const acc = accum.get(a.cluster_id) ?? { pc1: 0, pc2: 0, n: 0 };
+      acc.pc1 += a.pc1;
+      acc.pc2 += a.pc2;
+      acc.n += 1;
+      accum.set(a.cluster_id, acc);
+    }
+    for (const [cid, acc] of accum) {
+      clusterCoords.set(cid, { pc1: acc.pc1 / acc.n, pc2: acc.pc2 / acc.n });
+    }
+    const positive: Summary[] = [];
+    const negative: Summary[] = [];
+    for (const s of selectedSummaries) {
+      const coord = clusterCoords.get(s.cluster_id);
+      if (!coord) continue;
+      const value = axis === "pc1" ? coord.pc1 : coord.pc2;
+      if (value >= 0) positive.push(s);
+      else negative.push(s);
+    }
+    return { positive, negative };
+  }, [selectedQuestion, selectedInsight, assignments, selectedSummaries]);
+
+  const scatterBounds = useMemo(() => {
+    if (assignments.length === 0) {
+      return { minX: -1, maxX: 1, minY: -1, maxY: 1 };
+    }
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (const a of assignments) {
+      if (a.pc1 < minX) minX = a.pc1;
+      if (a.pc1 > maxX) maxX = a.pc1;
+      if (a.pc2 < minY) minY = a.pc2;
+      if (a.pc2 > maxY) maxY = a.pc2;
+    }
+    const padX = (maxX - minX) * 0.1 || 0.5;
+    const padY = (maxY - minY) * 0.1 || 0.5;
+    return {
+      minX: minX - padX,
+      maxX: maxX + padX,
+      minY: minY - padY,
+      maxY: maxY + padY,
+    };
+  }, [assignments]);
+
+  if (isLoading && !payload) {
+    return <div className="text-sm text-text-muted">読み込み中...</div>;
+  }
+
+  if (!run) {
+    return (
+      <div className="space-y-4">
+        <div className="bg-white border border-border rounded-xl p-6">
+          <h3 className="font-semibold mb-2">クラスター分析</h3>
+          <p className="text-sm text-text-secondary mb-4">
+            まだ計算結果がありません。「再計算」ボタンを押して PCA + k-means
+            を実行してください。
+          </p>
+          <button
+            type="button"
+            onClick={handleRecompute}
+            disabled={isRecomputing}
+            className="px-4 py-2 bg-primary text-white rounded-lg text-sm font-medium disabled:opacity-50"
+          >
+            {isRecomputing ? "計算中..." : "再計算を実行"}
+          </button>
+          {error && <p className="text-sm text-error mt-3">{error}</p>}
+        </div>
+      </div>
+    );
+  }
+
+  const pc1Var = run.pca_explained_variance?.[0] ?? 0;
+  const pc2Var = run.pca_explained_variance?.[1] ?? 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Run meta + actions */}
+      <div className="bg-white border border-border rounded-xl p-4 flex items-center justify-between flex-wrap gap-3">
+        <div className="text-xs text-text-secondary space-x-3">
+          <span>
+            計算:{" "}
+            {run.calculated_at
+              ? new Date(run.calculated_at).toLocaleString("ja-JP")
+              : "—"}
+          </span>
+          <span>n={run.n_respondents}</span>
+          <span>K={run.k_chosen}</span>
+          <span>silhouette={run.silhouette_score?.toFixed(3) ?? "—"}</span>
+          <span>
+            理由要約:{" "}
+            {run.reasons_built_at
+              ? new Date(run.reasons_built_at).toLocaleString("ja-JP")
+              : "未実行"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleRecompute}
+            disabled={isRecomputing || isBuildingReasons}
+            className="px-3 py-1.5 bg-primary text-white rounded-md text-xs font-medium disabled:opacity-50"
+          >
+            {isRecomputing ? "再計算中..." : "再計算"}
+          </button>
+          <button
+            type="button"
+            onClick={handleBuildReasons}
+            disabled={isRecomputing || isBuildingReasons}
+            className="px-3 py-1.5 bg-accent text-white rounded-md text-xs font-medium disabled:opacity-50"
+          >
+            {isBuildingReasons ? "要約生成中..." : "理由を要約"}
+          </button>
+          <button
+            type="button"
+            onClick={handleDownloadJson}
+            disabled={!payload?.run}
+            className="px-3 py-1.5 border border-border text-text rounded-md text-xs font-medium disabled:opacity-50 hover:bg-surface"
+          >
+            JSONダウンロード
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Left: scatter + axis labels + selected question detail */}
+        <div className="space-y-4">
+          <div className="bg-white border border-border rounded-xl p-4">
+            <h4 className="font-semibold text-sm mb-2">意見空間 (PCA)</h4>
+            <div className="text-[11px] text-text-muted mb-3 space-y-0.5">
+              <div>
+                <b>PC1 ({(pc1Var * 100).toFixed(1)}%):</b>{" "}
+                {run.axis_labels?.pc1?.negative || "−"} ⇔{" "}
+                {run.axis_labels?.pc1?.positive || "+"}
+              </div>
+              <div>
+                <b>PC2 ({(pc2Var * 100).toFixed(1)}%):</b>{" "}
+                {run.axis_labels?.pc2?.negative || "−"} ⇔{" "}
+                {run.axis_labels?.pc2?.positive || "+"}
+              </div>
+            </div>
+            <ScatterPlot
+              assignments={assignments}
+              bounds={scatterBounds}
+              clusterIds={clusterIds}
+            />
+            <div className="flex flex-wrap gap-3 mt-2">
+              {clusterIds.map((c) => (
+                <div key={c} className="flex items-center gap-1.5">
+                  <div
+                    className="w-3 h-3 rounded"
+                    style={{
+                      backgroundColor:
+                        CLUSTER_COLORS[c % CLUSTER_COLORS.length],
+                    }}
+                  />
+                  <span className="text-[11px] text-text-muted">
+                    Cluster {c} (n={clusterSizes.get(c) ?? 0})
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {selectedQuestion && (
+            <div className="bg-white border border-border rounded-xl p-4 space-y-3">
+              <div>
+                <h4 className="font-semibold text-sm">
+                  {selectedQuestion.toUpperCase()}
+                </h4>
+                <p className="text-xs text-text-secondary mt-1 leading-relaxed">
+                  {QUESTION_TEXTS[selectedQuestion]}
+                </p>
+              </div>
+              {selectedInsight?.insight_text && (
+                <div className="bg-yellow-50 border-l-4 border-yellow-400 p-3 text-xs leading-relaxed">
+                  <b className="text-yellow-700">分析:</b>{" "}
+                  {selectedInsight.insight_text}
+                </div>
+              )}
+              <PolaritySection
+                axis={selectedInsight?.dominant_axis ?? "pc1"}
+                axisLabels={run.axis_labels}
+                positive={polarityGroups.positive}
+                negative={polarityGroups.negative}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Right: question list */}
+        <div className="bg-white border border-border rounded-xl p-4">
+          <div className="flex items-center justify-between mb-3">
+            <h4 className="font-semibold text-sm">質問一覧</h4>
+            <select
+              value={sortBy}
+              onChange={(e) =>
+                setSortBy(e.target.value as "default" | "high" | "low")
+              }
+              className="text-xs px-2 py-1 border border-border rounded"
+            >
+              <option value="default">設問順</option>
+              <option value="high">不合意度 高→低</option>
+              <option value="low">不合意度 低→高</option>
+            </select>
+          </div>
+          <div className="space-y-1 max-h-[600px] overflow-y-auto">
+            {questionList.map((item) => {
+              const isSelected = item.qid === selectedQuestion;
+              return (
+                <button
+                  type="button"
+                  key={item.qid}
+                  onClick={() => setSelectedQuestion(item.qid)}
+                  className={`block w-full text-left p-2 rounded border-l-4 ${
+                    isSelected
+                      ? "bg-blue-50 border-blue-400"
+                      : "bg-white border-transparent hover:bg-gray-50"
+                  }`}
+                >
+                  <div className="text-xs font-medium">
+                    {item.qid.toUpperCase()}
+                    {item.disagreement !== null && (
+                      <span className="ml-2 text-text-muted font-normal">
+                        (不合意度 {item.disagreement.toFixed(2)})
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-[11px] text-text-secondary mt-0.5 leading-relaxed">
+                    {QUESTION_TEXTS[item.qid]?.slice(0, 70)}
+                    {QUESTION_TEXTS[item.qid] &&
+                    QUESTION_TEXTS[item.qid].length > 70
+                      ? "..."
+                      : ""}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ScatterPlot({
+  assignments,
+  bounds,
+  clusterIds,
+}: {
+  assignments: Assignment[];
+  bounds: { minX: number; maxX: number; minY: number; maxY: number };
+  clusterIds: number[];
+}) {
+  const width = 480;
+  const height = 360;
+  const padding = 30;
+
+  const toX = (v: number) =>
+    padding +
+    ((v - bounds.minX) / (bounds.maxX - bounds.minX)) * (width - padding * 2);
+  const toY = (v: number) =>
+    height -
+    padding -
+    ((v - bounds.minY) / (bounds.maxY - bounds.minY)) * (height - padding * 2);
+
+  const zeroX = toX(0);
+  const zeroY = toY(0);
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-auto bg-gray-50 rounded"
+      role="img"
+      aria-label="Opinion space scatter plot"
+    >
+      <title>Opinion space (PCA scatter)</title>
+      {/* Axes (zero lines) */}
+      <line
+        x1={zeroX}
+        y1={padding}
+        x2={zeroX}
+        y2={height - padding}
+        stroke="#ccc"
+        strokeWidth="0.5"
+      />
+      <line
+        x1={padding}
+        y1={zeroY}
+        x2={width - padding}
+        y2={zeroY}
+        stroke="#ccc"
+        strokeWidth="0.5"
+      />
+      {/* Border */}
+      <rect
+        x={padding}
+        y={padding}
+        width={width - padding * 2}
+        height={height - padding * 2}
+        fill="none"
+        stroke="#e5e7eb"
+        strokeWidth="1"
+      />
+      {assignments.map((a) => {
+        const color = CLUSTER_COLORS[a.cluster_id % CLUSTER_COLORS.length];
+        return (
+          <circle
+            key={a.session_id}
+            cx={toX(a.pc1)}
+            cy={toY(a.pc2)}
+            r={4}
+            fill={color}
+            fillOpacity={0.7}
+            stroke="#fff"
+            strokeWidth={0.5}
+          >
+            <title>
+              Cluster {a.cluster_id} / session {a.session_id.slice(0, 8)}
+            </title>
+          </circle>
+        );
+      })}
+      {/* Cluster labels (k=center label) */}
+      {clusterIds.map((c) => {
+        const points = assignments.filter((a) => a.cluster_id === c);
+        if (points.length === 0) return null;
+        const cx = points.reduce((s, p) => s + p.pc1, 0) / points.length;
+        const cy = points.reduce((s, p) => s + p.pc2, 0) / points.length;
+        return (
+          <text
+            key={`label-${c}`}
+            x={toX(cx)}
+            y={toY(cy)}
+            textAnchor="middle"
+            dy={-6}
+            fontSize="11"
+            fontWeight="bold"
+            fill="#333"
+            stroke="#fff"
+            strokeWidth="3"
+            paintOrder="stroke"
+          >
+            C{c}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}
+
+function PolaritySection({
+  axis,
+  axisLabels,
+  positive,
+  negative,
+}: {
+  axis: "pc1" | "pc2";
+  axisLabels: ClusterRun["axis_labels"];
+  positive: Summary[];
+  negative: Summary[];
+}) {
+  const labels = axisLabels?.[axis];
+  const posLabel = labels?.positive || `${axis.toUpperCase()}+`;
+  const negLabel = labels?.negative || `${axis.toUpperCase()}-`;
+
+  return (
+    <div className="space-y-3 text-xs">
+      <div>
+        <div className="px-2 py-1 bg-amber-100 rounded text-[11px] font-semibold mb-2">
+          {axis.toUpperCase()}+ ({posLabel})
+        </div>
+        {positive.length === 0 ? (
+          <p className="text-text-muted">該当クラスタなし</p>
+        ) : (
+          positive.map((s) => (
+            <SummaryCard key={`pos-${s.cluster_id}`} summary={s} />
+          ))
+        )}
+      </div>
+      <div>
+        <div className="px-2 py-1 bg-amber-100 rounded text-[11px] font-semibold mb-2">
+          {axis.toUpperCase()}- ({negLabel})
+        </div>
+        {negative.length === 0 ? (
+          <p className="text-text-muted">該当クラスタなし</p>
+        ) : (
+          negative.map((s) => (
+            <SummaryCard key={`neg-${s.cluster_id}`} summary={s} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({ summary }: { summary: Summary }) {
+  const color = CLUSTER_COLORS[summary.cluster_id % CLUSTER_COLORS.length];
+  return (
+    <div
+      className="mb-2 p-2 bg-white border-l-4 rounded"
+      style={{ borderLeftColor: color }}
+    >
+      <div className="font-semibold mb-1">Cluster {summary.cluster_id}</div>
+      <div className="text-text-secondary leading-relaxed">
+        {summary.summary || "(要約未生成)"}
+      </div>
+      <div className="text-[10px] text-text-muted mt-1">
+        n={summary.n_texts} ・ Diversity:{" "}
+        {summary.diversity_score !== null &&
+        summary.diversity_score !== undefined
+          ? summary.diversity_score.toFixed(3)
+          : "—"}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -12,6 +12,7 @@ import {
   LIKERT_OPTIONS,
   SURVEY_QUESTIONS,
 } from "@/lib/survey-data";
+import { ClusterAnalysisTab } from "./ClusterAnalysisTab";
 
 interface AnswerRow {
   question_id: string;
@@ -92,7 +93,7 @@ export default function AdminPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
-    "overview" | "q1-13" | "q14-18" | "responses"
+    "overview" | "q1-13" | "q14-18" | "responses" | "cluster"
   >("overview");
   const [expandedSessions, setExpandedSessions] = useState<Set<string>>(
     new Set(),
@@ -300,13 +301,7 @@ export default function AdminPage() {
   if (!data) return null;
 
   // Sort indicator
-  const SortHeader = ({
-    label,
-    sortId,
-  }: {
-    label: string;
-    sortId: string;
-  }) => (
+  const SortHeader = ({ label, sortId }: { label: string; sortId: string }) => (
     <th
       className="px-2 py-2 text-left font-medium text-text-muted cursor-pointer hover:text-text select-none whitespace-nowrap"
       onClick={() => toggleSort(sortId)}
@@ -381,6 +376,7 @@ export default function AdminPage() {
               ["q1-13", "Q1-Q13 詳細"],
               ["q14-18", "フォローアップ"],
               ["responses", "個別回答"],
+              ["cluster", "クラスター分析"],
             ] as const
           ).map(([key, label]) => (
             <button
@@ -610,10 +606,7 @@ export default function AdminPage() {
                 {/* Legend */}
                 <div className="flex flex-wrap gap-2">
                   {LIKERT_OPTIONS.map((opt) => (
-                    <div
-                      key={opt.value}
-                      className="flex items-center gap-1"
-                    >
+                    <div key={opt.value} className="flex items-center gap-1">
                       <span
                         className={`inline-block w-3 h-3 rounded-sm ${LIKERT_COLORS[opt.value]}`}
                       />
@@ -661,8 +654,7 @@ export default function AdminPage() {
                     const answerMap = getAnswerMap(s.session_id);
                     const followups =
                       data.followupBySession[s.session_id] || [];
-                    const isHighlighted =
-                      highlightedSession === s.session_id;
+                    const isHighlighted = highlightedSession === s.session_id;
                     return (
                       <tr
                         key={s.session_id}
@@ -732,6 +724,8 @@ export default function AdminPage() {
             </div>
           </div>
         )}
+
+        {activeTab === "cluster" && <ClusterAnalysisTab password={password} />}
       </main>
 
       {/* Fixed tooltip */}

--- a/src/app/api/admin/cluster/build-reasons/route.ts
+++ b/src/app/api/admin/cluster/build-reasons/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { checkAdminAuth } from "@/lib/admin-auth";
+import { buildReasons } from "@/lib/cluster-pipeline";
+
+export const maxDuration = 300;
+
+export async function POST(req: NextRequest) {
+  if (!checkAdminAuth(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const body = await req.json().catch(() => ({}));
+    const runId = typeof body?.run_id === "string" ? body.run_id : null;
+    const result = await buildReasons(runId);
+    return NextResponse.json(result);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error("build-reasons failed:", e);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/cluster/latest/route.ts
+++ b/src/app/api/admin/cluster/latest/route.ts
@@ -1,0 +1,61 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { checkAdminAuth } from "@/lib/admin-auth";
+import { createAdminClient } from "@/lib/supabase";
+
+export async function GET(req: NextRequest) {
+  if (!checkAdminAuth(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createAdminClient();
+  const url = new URL(req.url);
+  const explicitRunId = url.searchParams.get("run_id");
+
+  let runId = explicitRunId;
+  if (!runId) {
+    const { data: latest } = await supabase
+      .from("cluster_runs")
+      .select("id")
+      .order("calculated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    runId = latest?.id ?? null;
+  }
+  if (!runId) {
+    return NextResponse.json({
+      run: null,
+      assignments: [],
+      summaries: [],
+      insights: [],
+    });
+  }
+
+  const [runRes, assignRes, sumRes, insRes] = await Promise.all([
+    supabase.from("cluster_runs").select("*").eq("id", runId).single(),
+    supabase
+      .from("cluster_assignments")
+      .select("session_id, cluster_id, pc1, pc2")
+      .eq("cluster_run_id", runId),
+    supabase
+      .from("cluster_summaries")
+      .select(
+        "cluster_id, question_id, summary, diversity_score, n_texts, mean_in, mean_out, diff, representativeness",
+      )
+      .eq("cluster_run_id", runId),
+    supabase
+      .from("cluster_insights")
+      .select("question_id, insight_text, dominant_axis, disagreement_std")
+      .eq("cluster_run_id", runId),
+  ]);
+
+  if (runRes.error) {
+    return NextResponse.json({ error: runRes.error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    run: runRes.data,
+    assignments: assignRes.data ?? [],
+    summaries: sumRes.data ?? [],
+    insights: insRes.data ?? [],
+  });
+}

--- a/src/app/api/admin/cluster/recompute/route.ts
+++ b/src/app/api/admin/cluster/recompute/route.ts
@@ -1,0 +1,19 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { checkAdminAuth } from "@/lib/admin-auth";
+import { recomputeClusters } from "@/lib/cluster-pipeline";
+
+export const maxDuration = 60;
+
+export async function POST(req: NextRequest) {
+  if (!checkAdminAuth(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    const result = await recomputeClusters();
+    return NextResponse.json(result);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error("recompute failed:", e);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -6,10 +6,7 @@ export async function POST(req: NextRequest) {
     const { email } = await req.json();
 
     if (!email || typeof email !== "string") {
-      return NextResponse.json(
-        { error: "email is required" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "email is required" }, { status: 400 });
     }
 
     // Basic email validation

--- a/src/app/api/hints/route.ts
+++ b/src/app/api/hints/route.ts
@@ -7,7 +7,6 @@ import {
   SURVEY_QUESTIONS,
 } from "@/lib/survey-data";
 
-
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -451,9 +451,7 @@ export default function Home() {
         )}
 
         {/* Complete */}
-        {state === "complete" && (
-          <CompletePage />
-        )}
+        {state === "complete" && <CompletePage />}
       </main>
 
       {/* Sticky start button for intro */}

--- a/src/components/FraudEducationCarousel.tsx
+++ b/src/components/FraudEducationCarousel.tsx
@@ -92,13 +92,9 @@ export default function FraudEducationCarousel() {
             <div className="w-10 h-10 rounded-xl bg-accent/10 text-accent flex items-center justify-center shrink-0">
               {slide.icon}
             </div>
-            <Title>
-              {slide.title}
-            </Title>
+            <Title>{slide.title}</Title>
           </div>
-          <Typography>
-            {slide.copy}
-          </Typography>
+          <Typography>{slide.copy}</Typography>
           {slide.image && (
             <img
               src={slide.image}
@@ -106,9 +102,7 @@ export default function FraudEducationCarousel() {
               className="w-full"
             />
           )}
-          <Typography size="small">
-            {slide.body}
-          </Typography>
+          <Typography size="small">{slide.body}</Typography>
         </div>
       ))}
     </div>

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,8 @@
+import type { NextRequest } from "next/server";
+
+export function checkAdminAuth(req: NextRequest): boolean {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) return false;
+  const token = authHeader.slice(7);
+  return token === process.env.ADMIN_PASSWORD;
+}

--- a/src/lib/cluster-insights.ts
+++ b/src/lib/cluster-insights.ts
@@ -1,0 +1,153 @@
+// ============================================================
+// 質問ごとのクラスタ横断インサイト & PC1/PC2 軸ラベル
+// Issue #26/#27 (insight, axis labels はadminUI表示用)
+// ============================================================
+
+import { callOpenRouter } from "./openrouter";
+
+export interface AxisLabelInput {
+  loadingsByQuestion: Record<string, { pc1: number; pc2: number }>;
+  questionTexts: Record<string, string>;
+}
+
+export interface AxisLabels {
+  pc1: { positive: string; negative: string };
+  pc2: { positive: string; negative: string };
+}
+
+export async function generateAxisLabels(
+  input: AxisLabelInput,
+): Promise<AxisLabels> {
+  const qids = Object.keys(input.loadingsByQuestion);
+  const lines: string[] = [];
+  for (const qid of qids) {
+    const { pc1, pc2 } = input.loadingsByQuestion[qid];
+    const text = (input.questionTexts[qid] ?? "").slice(0, 80);
+    lines.push(
+      `- ${qid}: PC1負荷=${pc1.toFixed(3)}, PC2負荷=${pc2.toFixed(3)} / 設問: ${text}`,
+    );
+  }
+
+  const prompt = `あなたは社会調査のクラスタリング結果を解釈する分析者です。以下はPCAの第1・第2主成分への各設問の負荷量です。各軸の両極（+方向と−方向）が何を意味するかを、各6〜14文字程度の短いラベルで日本語で命名してください。
+
+${lines.join("\n")}
+
+出力は次のJSON形式のみ。前後に説明文を付けないでください:
+{
+  "pc1": { "positive": "...", "negative": "..." },
+  "pc2": { "positive": "...", "negative": "..." }
+}`;
+
+  const raw = await callOpenRouter([{ role: "user", content: prompt }], {
+    maxTokens: 400,
+    temperature: 0.2,
+  });
+  return parseAxisLabels(raw);
+}
+
+function parseAxisLabels(raw: string): AxisLabels {
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  const text = jsonMatch ? jsonMatch[0] : raw;
+  try {
+    const parsed = JSON.parse(text);
+    return {
+      pc1: {
+        positive: String(parsed?.pc1?.positive ?? "").slice(0, 30),
+        negative: String(parsed?.pc1?.negative ?? "").slice(0, 30),
+      },
+      pc2: {
+        positive: String(parsed?.pc2?.positive ?? "").slice(0, 30),
+        negative: String(parsed?.pc2?.negative ?? "").slice(0, 30),
+      },
+    };
+  } catch {
+    return {
+      pc1: { positive: "", negative: "" },
+      pc2: { positive: "", negative: "" },
+    };
+  }
+}
+
+export interface ClusterDataForInsight {
+  cluster_id: number;
+  n_respondents: number;
+  /** dont_know を除いた平均値 (-2 .. +2) */
+  mean_likert: number;
+  /** agree + strongly_agree の比率 (0..1) */
+  agree_rate: number;
+  /** disagree + strongly_disagree の比率 (0..1) */
+  disagree_rate: number;
+  /** dont_know の比率 (0..1) */
+  dont_know_rate: number;
+  /** 自由記述を書いた人数 */
+  n_freetexts: number;
+  /** ペア間 cosine 距離の平均 (理由テキストの分散度) */
+  diversity_score: number | null;
+  /** 自由記述の100字要約 */
+  summary: string;
+}
+
+export interface InsightInput {
+  question_id: string;
+  question_text: string;
+  dominant_axis: "pc1" | "pc2";
+  cluster_data: ClusterDataForInsight[];
+}
+
+function fmtPct(v: number): string {
+  return `${Math.round(v * 100)}%`;
+}
+
+function fmtSigned(v: number): string {
+  if (Number.isNaN(v)) return "—";
+  return v >= 0 ? `+${v.toFixed(2)}` : v.toFixed(2);
+}
+
+export async function generateQuestionInsight(
+  input: InsightInput,
+): Promise<string> {
+  const sorted = [...input.cluster_data].sort(
+    (a, b) => a.cluster_id - b.cluster_id,
+  );
+  const lines = sorted.map((c) => {
+    const diversity =
+      c.diversity_score !== null && c.diversity_score !== undefined
+        ? c.diversity_score.toFixed(3)
+        : "—";
+    const summary = c.summary?.trim() || "（自由記述なし）";
+    return [
+      `[Cluster ${c.cluster_id}] n=${c.n_respondents}`,
+      `  ・回答: 平均 ${fmtSigned(c.mean_likert)} / 賛成 ${fmtPct(c.agree_rate)} / 反対 ${fmtPct(c.disagree_rate)} / わからない ${fmtPct(c.dont_know_rate)}`,
+      `  ・自由記述: ${c.n_freetexts}件 / 多様性 ${diversity}`,
+      `  ・要約: ${summary}`,
+    ].join("\n");
+  });
+
+  const prompt = `あなたは熟議型世論調査の分析者です。次の設問に対する複数クラスタの回答状況と自由記述要約から、クラスタ横断の洞察を日本語300字程度で記述してください。
+
+含めるべき観点:
+- 賛否の構図: どのクラスタが賛成・反対・中立か (mean_likert と 賛成/反対率 を根拠に)
+- 多様性: 同じ立場でも理由が収束しているか分散しているか (diversity を根拠に)
+- 自由記述から読み取れる論理の特徴と、量的データだけでは見えない違い
+- 「表面的合意」(立場は同じだが理由が分散) と「実質的合意」(立場も理由も収束) の区別
+
+設問: ${input.question_text}
+主要分析軸: ${input.dominant_axis.toUpperCase()}
+
+クラスタ別データ:
+${lines.join("\n")}
+
+300字程度の日本語本文のみを出力（前置き・見出し・箇条書き不要）。`;
+
+  try {
+    return (
+      await callOpenRouter([{ role: "user", content: prompt }], {
+        maxTokens: 600,
+        temperature: 0.3,
+      })
+    ).trim();
+  } catch (e) {
+    console.error("generateQuestionInsight failed:", e);
+    return "";
+  }
+}

--- a/src/lib/cluster-pipeline.ts
+++ b/src/lib/cluster-pipeline.ts
@@ -1,0 +1,477 @@
+// ============================================================
+// クラスタリング・要約パイプラインのオーケストレーション
+// Issue #26: recompute (PCA + kmeans + 永続化)
+// Issue #27: build-reasons (embedding + 要約 + insight + 軸ラベル)
+// ============================================================
+
+import {
+  generateAxisLabels,
+  generateQuestionInsight,
+} from "./cluster-insights";
+import {
+  type ClusterQuestionGroup,
+  summarizeAllGroups,
+} from "./cluster-summarization";
+import {
+  type AnswerInput,
+  buildResponseMatrix,
+  computeQuestionAxes,
+  computeRepresentativeness,
+  runKMeansWithBestK,
+  runPCA,
+} from "./clustering";
+import { ensureEmbeddings } from "./embeddings";
+import { createAdminClient } from "./supabase";
+import { SURVEY_QUESTIONS } from "./survey-data";
+
+interface AnswerRow {
+  id: string;
+  session_id: string;
+  question_id: string;
+  question_text: string | null;
+  likert: string | null;
+  freetext: string | null;
+  is_followup: boolean | null;
+}
+
+async function fetchAllBaseAnswers(): Promise<AnswerRow[]> {
+  const supabase = createAdminClient();
+  const PAGE_SIZE = 1000;
+  const out: AnswerRow[] = [];
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from("answers")
+      .select(
+        "id, session_id, question_id, question_text, likert, freetext, is_followup",
+      )
+      .eq("is_followup", false)
+      .range(from, from + PAGE_SIZE - 1);
+    if (error) throw new Error(`answers fetch error: ${error.message}`);
+    if (!data || data.length === 0) break;
+    out.push(...(data as AnswerRow[]));
+    if (data.length < PAGE_SIZE) break;
+  }
+  return out;
+}
+
+function buildQuestionTexts(answers: AnswerRow[]): Record<string, string> {
+  // survey-data.ts を一次ソースとし、補完として answers 側の question_text を使う
+  const out: Record<string, string> = {};
+  for (const q of SURVEY_QUESTIONS) out[q.id] = q.text;
+  const fallback = new Map<string, Map<string, number>>();
+  for (const a of answers) {
+    if (!a.question_text) continue;
+    if (out[a.question_id]) continue;
+    if (!fallback.has(a.question_id)) fallback.set(a.question_id, new Map());
+    const m = fallback.get(a.question_id);
+    if (!m) continue;
+    m.set(a.question_text, (m.get(a.question_text) ?? 0) + 1);
+  }
+  for (const [qid, counts] of fallback.entries()) {
+    let best = "";
+    let bestN = -1;
+    for (const [t, n] of counts)
+      if (n > bestN) {
+        best = t;
+        bestN = n;
+      }
+    if (best) out[qid] = best;
+  }
+  return out;
+}
+
+export interface RecomputeResult {
+  cluster_run_id: string;
+  n_respondents: number;
+  n_questions: number;
+  k_chosen: number;
+  silhouette_score: number;
+}
+
+/**
+ * Recompute: 全回答からPCA→kmeans→代表設問抽出→DB永続化
+ */
+export async function recomputeClusters(): Promise<RecomputeResult> {
+  const supabase = createAdminClient();
+  const answers = await fetchAllBaseAnswers();
+
+  const matrix = buildResponseMatrix(answers as AnswerInput[], {
+    minAnsweredPerSession: 1,
+  });
+
+  if (matrix.sessionIds.length < 4) {
+    throw new Error(
+      `分析対象の回答者数が不足しています (${matrix.sessionIds.length}名). 4名以上必要です.`,
+    );
+  }
+
+  const pca = runPCA(matrix);
+  const km = runKMeansWithBestK(pca.coords, {
+    kRange: [2, 3, 4, 5, 6].filter((k) => k <= matrix.sessionIds.length),
+  });
+  const repr = computeRepresentativeness(matrix, km.labels);
+  const axes = computeQuestionAxes(matrix, pca, km.labels);
+
+  // cluster_runs 挿入
+  const { data: runRow, error: runErr } = await supabase
+    .from("cluster_runs")
+    .insert({
+      n_respondents: matrix.sessionIds.length,
+      n_questions: matrix.questionIds.length,
+      k_chosen: km.bestK,
+      silhouette_score: km.silhouette,
+      pca_explained_variance: pca.explainedVariance,
+      pca_loadings: pca.loadingsByQuestion,
+      silhouette_by_k: km.silhouetteByK,
+      question_ids: matrix.questionIds,
+      params: {
+        center: true,
+        scale: false,
+        kmeans_n_init: 10,
+        k_range: [2, 6],
+      },
+    })
+    .select("id")
+    .single();
+  if (runErr || !runRow) {
+    throw new Error(`cluster_runs insert failed: ${runErr?.message}`);
+  }
+  const runId = runRow.id;
+
+  // assignments
+  const assignments = matrix.sessionIds.map((sid, i) => ({
+    cluster_run_id: runId,
+    session_id: sid,
+    cluster_id: km.labels[i],
+    pc1: pca.coords[i][0],
+    pc2: pca.coords[i][1],
+  }));
+  const { error: aErr } = await supabase
+    .from("cluster_assignments")
+    .insert(assignments);
+  if (aErr)
+    throw new Error(`cluster_assignments insert failed: ${aErr.message}`);
+
+  // summaries (まずは数値だけ。要約・diversityは build-reasons で埋める)
+  const summaries = repr.map((r) => ({
+    cluster_run_id: runId,
+    cluster_id: r.cluster_id,
+    question_id: r.question_id,
+    summary: "",
+    diversity_score: null,
+    n_texts: 0,
+    mean_in: r.mean_in,
+    mean_out: r.mean_out,
+    diff: r.diff,
+    representativeness: r.representativeness,
+  }));
+  const { error: sErr } = await supabase
+    .from("cluster_summaries")
+    .insert(summaries);
+  if (sErr) throw new Error(`cluster_summaries insert failed: ${sErr.message}`);
+
+  // axes/insights (insight_text は空で初期化、build-reasons で埋める)
+  const insightsInit = axes.map((a) => ({
+    cluster_run_id: runId,
+    question_id: a.question_id,
+    insight_text: "",
+    dominant_axis: a.dominant_axis,
+    disagreement_std: a.disagreement_std,
+  }));
+  const { error: iErr } = await supabase
+    .from("cluster_insights")
+    .insert(insightsInit);
+  if (iErr) throw new Error(`cluster_insights insert failed: ${iErr.message}`);
+
+  return {
+    cluster_run_id: runId,
+    n_respondents: matrix.sessionIds.length,
+    n_questions: matrix.questionIds.length,
+    k_chosen: km.bestK,
+    silhouette_score: km.silhouette,
+  };
+}
+
+export interface BuildReasonsResult {
+  cluster_run_id: string;
+  n_embeddings: number;
+  n_summaries: number;
+  n_insights: number;
+}
+
+/**
+ * Build reasons: 最新 cluster_run に対して
+ * 1) freetext を embedding化
+ * 2) (cluster, question)単位の要約 + 多様性スコア
+ * 3) 質問ごとの insight + 軸ラベル
+ */
+export async function buildReasons(
+  runId: string | null = null,
+): Promise<BuildReasonsResult> {
+  const supabase = createAdminClient();
+
+  // 対象 cluster_run を確定
+  let targetRunId = runId;
+  if (!targetRunId) {
+    const { data: latest } = await supabase
+      .from("cluster_runs")
+      .select("id")
+      .order("calculated_at", { ascending: false })
+      .limit(1)
+      .single();
+    if (!latest)
+      throw new Error(
+        "cluster_run が存在しません. 先に recompute を実行してください.",
+      );
+    targetRunId = latest.id;
+  }
+
+  // 割り当てと回答取得
+  const { data: assignments } = await supabase
+    .from("cluster_assignments")
+    .select("session_id, cluster_id")
+    .eq("cluster_run_id", targetRunId);
+  if (!assignments || assignments.length === 0) {
+    throw new Error("cluster_assignments が見つかりません.");
+  }
+  const sessionToCluster = new Map<string, number>();
+  for (const a of assignments) sessionToCluster.set(a.session_id, a.cluster_id);
+
+  const sessionIds = assignments.map((a) => a.session_id);
+  const answers: AnswerRow[] = [];
+  const PAGE_SIZE = 1000;
+  for (let from = 0; from < sessionIds.length; from += PAGE_SIZE) {
+    const slice = sessionIds.slice(from, from + PAGE_SIZE);
+    const { data, error } = await supabase
+      .from("answers")
+      .select(
+        "id, session_id, question_id, question_text, likert, freetext, is_followup",
+      )
+      .eq("is_followup", false)
+      .in("session_id", slice);
+    if (error) throw new Error(`answers fetch error: ${error.message}`);
+    if (data) answers.push(...(data as AnswerRow[]));
+  }
+
+  // 自由記述を embedding化
+  const freetextAnswers = answers
+    .filter((a) => a.freetext && a.freetext.trim().length > 0)
+    .map((a) => ({
+      answer_id: a.id,
+      session_id: a.session_id,
+      question_id: a.question_id,
+      text: (a.freetext ?? "").trim(),
+    }));
+  const embByAnswer = await ensureEmbeddings(freetextAnswers);
+
+  // (cluster_id, question_id) でグループ化
+  const questionTexts = buildQuestionTexts(answers);
+  const groupMap = new Map<string, ClusterQuestionGroup>();
+  for (const a of answers) {
+    const text = (a.freetext ?? "").trim();
+    if (!text) continue;
+    const cluster = sessionToCluster.get(a.session_id);
+    if (cluster === undefined) continue;
+    const key = `${cluster}::${a.question_id}`;
+    if (!groupMap.has(key)) {
+      groupMap.set(key, {
+        cluster_id: cluster,
+        question_id: a.question_id,
+        question_text: questionTexts[a.question_id] ?? a.question_text ?? "",
+        texts: [],
+      });
+    }
+    const emb = embByAnswer.get(a.id);
+    if (!emb) continue;
+    groupMap.get(key)?.texts.push({ answer_id: a.id, text, embedding: emb });
+  }
+  const groups = [...groupMap.values()];
+
+  // 要約 + 多様性スコア
+  const summaries = await summarizeAllGroups(groups);
+
+  // DB更新: cluster_summaries の summary/diversity/n_texts を埋める
+  for (const s of summaries) {
+    await supabase
+      .from("cluster_summaries")
+      .update({
+        summary: s.summary,
+        diversity_score: s.diversity_score,
+        n_texts: s.n_texts,
+      })
+      .eq("cluster_run_id", targetRunId)
+      .eq("cluster_id", s.cluster_id)
+      .eq("question_id", s.question_id);
+  }
+
+  // Likertの実分布をクラスタ×設問単位で集計（imputed値ではなく生回答）
+  const clusterSizes = new Map<number, number>();
+  for (const cid of sessionToCluster.values()) {
+    clusterSizes.set(cid, (clusterSizes.get(cid) ?? 0) + 1);
+  }
+  type LikertStat = {
+    cluster_id: number;
+    question_id: string;
+    n_strongly_agree: number;
+    n_agree: number;
+    n_neutral: number;
+    n_disagree: number;
+    n_strongly_disagree: number;
+    n_dont_know: number;
+  };
+  const statKey = (c: number, q: string) => `${c}::${q}`;
+  const stats = new Map<string, LikertStat>();
+  for (const a of answers) {
+    const cluster = sessionToCluster.get(a.session_id);
+    if (cluster === undefined) continue;
+    if (!a.likert) continue;
+    const key = statKey(cluster, a.question_id);
+    if (!stats.has(key)) {
+      stats.set(key, {
+        cluster_id: cluster,
+        question_id: a.question_id,
+        n_strongly_agree: 0,
+        n_agree: 0,
+        n_neutral: 0,
+        n_disagree: 0,
+        n_strongly_disagree: 0,
+        n_dont_know: 0,
+      });
+    }
+    const s = stats.get(key);
+    if (!s) continue;
+    if (a.likert === "strongly_agree") s.n_strongly_agree++;
+    else if (a.likert === "agree") s.n_agree++;
+    else if (a.likert === "neutral") s.n_neutral++;
+    else if (a.likert === "disagree") s.n_disagree++;
+    else if (a.likert === "strongly_disagree") s.n_strongly_disagree++;
+    else if (a.likert === "dont_know") s.n_dont_know++;
+  }
+
+  function buildClusterData(qid: string, cid: number) {
+    const s = stats.get(statKey(cid, qid));
+    const total = clusterSizes.get(cid) ?? 0;
+    const n_answered = s
+      ? s.n_strongly_agree +
+        s.n_agree +
+        s.n_neutral +
+        s.n_disagree +
+        s.n_strongly_disagree +
+        s.n_dont_know
+      : 0;
+    const n_valid = s
+      ? s.n_strongly_agree +
+        s.n_agree +
+        s.n_neutral +
+        s.n_disagree +
+        s.n_strongly_disagree
+      : 0;
+    const mean_likert =
+      n_valid === 0
+        ? Number.NaN
+        : (2 * (s?.n_strongly_agree ?? 0) +
+            1 * (s?.n_agree ?? 0) +
+            0 * (s?.n_neutral ?? 0) -
+            1 * (s?.n_disagree ?? 0) -
+            2 * (s?.n_strongly_disagree ?? 0)) /
+          n_valid;
+    const agree_rate =
+      n_answered === 0
+        ? 0
+        : ((s?.n_strongly_agree ?? 0) + (s?.n_agree ?? 0)) / n_answered;
+    const disagree_rate =
+      n_answered === 0
+        ? 0
+        : ((s?.n_strongly_disagree ?? 0) + (s?.n_disagree ?? 0)) / n_answered;
+    const dont_know_rate =
+      n_answered === 0 ? 0 : (s?.n_dont_know ?? 0) / n_answered;
+    const summary = summaries.find(
+      (x) => x.cluster_id === cid && x.question_id === qid,
+    );
+    return {
+      cluster_id: cid,
+      n_respondents: total,
+      mean_likert,
+      agree_rate,
+      disagree_rate,
+      dont_know_rate,
+      n_freetexts: summary?.n_texts ?? 0,
+      diversity_score: summary?.diversity_score ?? null,
+      summary: summary?.summary ?? "",
+    };
+  }
+
+  // 全クラスタIDと全質問IDを収集（自由記述の有無に関わらず全問題で insight 生成）
+  const allClusterIds = [...clusterSizes.keys()].sort((a, b) => a - b);
+  const { data: runRowForQids } = await supabase
+    .from("cluster_runs")
+    .select("question_ids")
+    .eq("id", targetRunId)
+    .single();
+  const allQuestionIds = (runRowForQids?.question_ids as string[] | null) ?? [];
+
+  // dominant_axis を質問ごとに取得
+  const { data: insightRows } = await supabase
+    .from("cluster_insights")
+    .select("question_id, dominant_axis")
+    .eq("cluster_run_id", targetRunId);
+  const axisByQuestion = new Map<string, "pc1" | "pc2">();
+  for (const r of insightRows ?? []) {
+    if (r.dominant_axis === "pc1" || r.dominant_axis === "pc2") {
+      axisByQuestion.set(r.question_id, r.dominant_axis);
+    }
+  }
+
+  let insightCount = 0;
+  const insightTasks = allQuestionIds.map(async (qid) => {
+    const clusterData = allClusterIds.map((cid) => buildClusterData(qid, cid));
+    const insight = await generateQuestionInsight({
+      question_id: qid,
+      question_text: questionTexts[qid] ?? "",
+      dominant_axis: axisByQuestion.get(qid) ?? "pc1",
+      cluster_data: clusterData,
+    });
+    await supabase
+      .from("cluster_insights")
+      .update({ insight_text: insight })
+      .eq("cluster_run_id", targetRunId)
+      .eq("question_id", qid);
+    insightCount++;
+  });
+  // 並列度制限
+  const CHUNK = 3;
+  for (let i = 0; i < insightTasks.length; i += CHUNK) {
+    await Promise.all(insightTasks.slice(i, i + CHUNK));
+  }
+
+  // 軸ラベル生成 → cluster_runs.axis_labels に保存
+  const { data: runRow } = await supabase
+    .from("cluster_runs")
+    .select("pca_loadings, question_ids")
+    .eq("id", targetRunId)
+    .single();
+  if (runRow) {
+    const loadings = runRow.pca_loadings as Record<
+      string,
+      { pc1: number; pc2: number }
+    >;
+    const axisLabels = await generateAxisLabels({
+      loadingsByQuestion: loadings,
+      questionTexts,
+    });
+    await supabase
+      .from("cluster_runs")
+      .update({
+        axis_labels: JSON.parse(JSON.stringify(axisLabels)),
+        reasons_built_at: new Date().toISOString(),
+      })
+      .eq("id", targetRunId);
+  }
+
+  return {
+    cluster_run_id: targetRunId,
+    n_embeddings: embByAnswer.size,
+    n_summaries: summaries.length,
+    n_insights: insightCount,
+  };
+}

--- a/src/lib/cluster-summarization.ts
+++ b/src/lib/cluster-summarization.ts
@@ -1,0 +1,82 @@
+// ============================================================
+// クラスタ × 設問ごとの理由テキスト要約 + 多様性スコア
+// Issue #27
+// ============================================================
+
+import { meanPairwiseCosineDistance } from "./embeddings";
+import { callOpenRouter } from "./openrouter";
+
+export interface ClusterQuestionGroup {
+  cluster_id: number;
+  question_id: string;
+  question_text: string;
+  texts: { answer_id: string; text: string; embedding: number[] }[];
+}
+
+export interface ClusterQuestionSummary {
+  cluster_id: number;
+  question_id: string;
+  summary: string;
+  diversity_score: number | null;
+  n_texts: number;
+}
+
+export async function summarizeClusterQuestion(
+  group: ClusterQuestionGroup,
+): Promise<ClusterQuestionSummary> {
+  const n = group.texts.length;
+  if (n === 0) {
+    return {
+      cluster_id: group.cluster_id,
+      question_id: group.question_id,
+      summary: "",
+      diversity_score: null,
+      n_texts: 0,
+    };
+  }
+
+  const diversity = meanPairwiseCosineDistance(
+    group.texts.map((t) => t.embedding),
+  );
+
+  const textBlock = group.texts.map((t) => `- ${t.text}`).join("\n");
+  const prompt = `以下のテキスト群は、ある回答者グループが設問「${group.question_text}」に対して示した理由です。
+彼らがなぜこの立場を取るかを100字以内の日本語で要約してください。前置きや「要約:」などのラベルは付けず、要約本文のみを出力してください。
+
+テキスト群:
+${textBlock}`;
+
+  let summary = "";
+  try {
+    summary = (
+      await callOpenRouter([{ role: "user", content: prompt }], {
+        maxTokens: 200,
+        temperature: 0.3,
+      })
+    ).trim();
+  } catch (e) {
+    console.error("summarizeClusterQuestion failed:", e);
+  }
+
+  return {
+    cluster_id: group.cluster_id,
+    question_id: group.question_id,
+    summary,
+    diversity_score: diversity,
+    n_texts: n,
+  };
+}
+
+export async function summarizeAllGroups(
+  groups: ClusterQuestionGroup[],
+): Promise<ClusterQuestionSummary[]> {
+  // 並列度を制限して逐次に近い処理（OpenRouter & llm_cache負荷の都合）
+  const results: ClusterQuestionSummary[] = [];
+  const CONCURRENCY = 3;
+  for (let i = 0; i < groups.length; i += CONCURRENCY) {
+    const batch = groups.slice(i, i + CONCURRENCY);
+    const r = await Promise.all(batch.map(summarizeClusterQuestion));
+    results.push(...r);
+  }
+  return results;
+}

--- a/src/lib/clustering.ts
+++ b/src/lib/clustering.ts
@@ -1,0 +1,332 @@
+// ============================================================
+// クラスタリング・PCA パイプライン
+// Issue #26: リッカートデータのクラスタリングと可視化
+// Polis流: 列平均補完 → センタリング → PCA → kmeans (silhouette最良K)
+// ============================================================
+
+import { kmeans } from "ml-kmeans";
+import { PCA } from "ml-pca";
+import { numericFromLikert } from "./likert";
+
+export interface AnswerInput {
+  session_id: string;
+  question_id: string;
+  likert: string | null;
+  is_followup: boolean | null;
+}
+
+export interface ResponseMatrix {
+  sessionIds: string[];
+  questionIds: string[];
+  values: number[][];
+  rawValues: (number | null)[][];
+}
+
+export interface PCAResult {
+  coords: number[][];
+  explainedVariance: number[];
+  loadings: { pc1: number[]; pc2: number[] };
+  loadingsByQuestion: Record<string, { pc1: number; pc2: number }>;
+}
+
+export interface KMeansResult {
+  bestK: number;
+  labels: number[];
+  silhouette: number;
+  silhouetteByK: Record<number, number>;
+}
+
+export interface RepresentativenessRow {
+  cluster_id: number;
+  question_id: string;
+  mean_in: number;
+  mean_out: number;
+  diff: number;
+  representativeness: number;
+}
+
+// ────────────────────────────────────────────────────────────
+// 1. matrix構築
+// ────────────────────────────────────────────────────────────
+export function buildResponseMatrix(
+  answers: AnswerInput[],
+  options?: { minAnsweredPerSession?: number },
+): ResponseMatrix {
+  const minAnswered = options?.minAnsweredPerSession ?? 1;
+
+  // is_followup=false の Likert回答のみ対象
+  const baseAnswers = answers.filter((a) => !a.is_followup && a.likert);
+
+  // 出現したquestion_idを収集（survey-data.tsとは独立。answers側で完結）
+  const qidSet = new Set<string>();
+  for (const a of baseAnswers) qidSet.add(a.question_id);
+  const questionIds = [...qidSet].sort((a, b) => {
+    const na = Number.parseInt(a.replace(/\D/g, ""), 10) || 0;
+    const nb = Number.parseInt(b.replace(/\D/g, ""), 10) || 0;
+    return na - nb;
+  });
+
+  // session_idごとに集約
+  const bySession = new Map<string, Map<string, number | null>>();
+  for (const a of baseAnswers) {
+    if (!bySession.has(a.session_id)) bySession.set(a.session_id, new Map());
+    bySession
+      .get(a.session_id)
+      ?.set(a.question_id, numericFromLikert(a.likert));
+  }
+
+  // 最低回答数フィルタ
+  const sessionIds: string[] = [];
+  const rawValues: (number | null)[][] = [];
+  for (const [sid, qMap] of bySession.entries()) {
+    const row = questionIds.map((qid) => qMap.get(qid) ?? null);
+    const answered = row.filter((v) => v !== null).length;
+    if (answered >= minAnswered) {
+      sessionIds.push(sid);
+      rawValues.push(row);
+    }
+  }
+
+  // 列平均補完
+  const values = rawValues.map((row) => row.slice()) as (number | null)[][];
+  for (let j = 0; j < questionIds.length; j++) {
+    let sum = 0;
+    let count = 0;
+    for (let i = 0; i < values.length; i++) {
+      const v = values[i][j];
+      if (v !== null) {
+        sum += v;
+        count++;
+      }
+    }
+    const mean = count > 0 ? sum / count : 0;
+    for (let i = 0; i < values.length; i++) {
+      if (values[i][j] === null) values[i][j] = mean;
+    }
+  }
+
+  return {
+    sessionIds,
+    questionIds,
+    values: values as number[][],
+    rawValues,
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// 2. PCA (2次元へ射影、Polis流: center=true, scale=false)
+// ────────────────────────────────────────────────────────────
+export function runPCA(matrix: ResponseMatrix): PCAResult {
+  const { values, questionIds } = matrix;
+  const pca = new PCA(values, { center: true, scale: false });
+  const projected = pca.predict(values, { nComponents: 2 });
+  const coords: number[][] = [];
+  for (let i = 0; i < projected.rows; i++) {
+    coords.push([projected.get(i, 0), projected.get(i, 1)]);
+  }
+  const explained = pca.getExplainedVariance().slice(0, 2);
+
+  // Loadings: rows=features (questions), cols=components.
+  // ml-pca の getLoadings() は components × features の行列を返す
+  const loadingsMatrix = pca.getLoadings();
+  const pc1: number[] = [];
+  const pc2: number[] = [];
+  const loadingsByQuestion: Record<string, { pc1: number; pc2: number }> = {};
+  for (let j = 0; j < questionIds.length; j++) {
+    const v1 = loadingsMatrix.get(0, j);
+    const v2 = loadingsMatrix.get(1, j);
+    pc1.push(v1);
+    pc2.push(v2);
+    loadingsByQuestion[questionIds[j]] = { pc1: v1, pc2: v2 };
+  }
+
+  return {
+    coords,
+    explainedVariance: explained,
+    loadings: { pc1, pc2 },
+    loadingsByQuestion,
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// 3. シルエットスコア（自前実装）
+// ────────────────────────────────────────────────────────────
+function euclideanDistance(a: number[], b: number[]): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) {
+    const d = a[i] - b[i];
+    s += d * d;
+  }
+  return Math.sqrt(s);
+}
+
+export function silhouetteScore(coords: number[][], labels: number[]): number {
+  const n = coords.length;
+  if (n === 0) return 0;
+  const clusters = new Set(labels);
+  if (clusters.size < 2) return 0;
+
+  // 各点と各クラスタの距離を事前計算
+  const scores: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const own = labels[i];
+    const inCluster: number[] = [];
+    const byOther = new Map<number, number[]>();
+    for (let j = 0; j < n; j++) {
+      if (j === i) continue;
+      const d = euclideanDistance(coords[i], coords[j]);
+      if (labels[j] === own) {
+        inCluster.push(d);
+      } else {
+        if (!byOther.has(labels[j])) byOther.set(labels[j], []);
+        byOther.get(labels[j])?.push(d);
+      }
+    }
+    const a =
+      inCluster.length > 0
+        ? inCluster.reduce((s, v) => s + v, 0) / inCluster.length
+        : 0;
+    let b = Number.POSITIVE_INFINITY;
+    for (const ds of byOther.values()) {
+      const meanD = ds.reduce((s, v) => s + v, 0) / ds.length;
+      if (meanD < b) b = meanD;
+    }
+    const s = inCluster.length === 0 ? 0 : (b - a) / Math.max(a, b);
+    scores.push(s);
+  }
+  return scores.reduce((s, v) => s + v, 0) / scores.length;
+}
+
+// ────────────────────────────────────────────────────────────
+// 4. kmeans + best K (K=2..6)
+// ────────────────────────────────────────────────────────────
+export function runKMeansWithBestK(
+  coords: number[][],
+  options?: { kRange?: number[]; seed?: number; nInit?: number },
+): KMeansResult {
+  const kRange = options?.kRange ?? [2, 3, 4, 5, 6];
+  const seed = options?.seed ?? 42;
+  const nInit = options?.nInit ?? 10;
+
+  const byK: Record<number, { labels: number[]; score: number }> = {};
+  for (const k of kRange) {
+    if (coords.length < k) continue;
+    let bestLabels: number[] = [];
+    let bestSse = Number.POSITIVE_INFINITY;
+    // 複数回初期化して最良SSEを選ぶ（sklearn n_init相当）
+    for (let r = 0; r < nInit; r++) {
+      const res = kmeans(coords, k, {
+        seed: seed + r,
+        initialization: "kmeans++",
+        maxIterations: 300,
+      });
+      // SSE: 各点と所属centroidの2乗距離合計
+      let sse = 0;
+      for (let i = 0; i < coords.length; i++) {
+        const c = res.centroids[res.clusters[i]];
+        const d = euclideanDistance(coords[i], c);
+        sse += d * d;
+      }
+      if (sse < bestSse) {
+        bestSse = sse;
+        bestLabels = res.clusters.slice();
+      }
+    }
+    byK[k] = { labels: bestLabels, score: silhouetteScore(coords, bestLabels) };
+  }
+
+  let bestK = kRange[0];
+  let bestScore = Number.NEGATIVE_INFINITY;
+  const silhouetteByK: Record<number, number> = {};
+  for (const k of Object.keys(byK).map(Number)) {
+    silhouetteByK[k] = byK[k].score;
+    if (byK[k].score > bestScore) {
+      bestScore = byK[k].score;
+      bestK = k;
+    }
+  }
+
+  return {
+    bestK,
+    labels: byK[bestK].labels,
+    silhouette: bestScore,
+    silhouetteByK,
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// 5. クラスタ代表設問: 群内平均 vs 群外平均
+// ────────────────────────────────────────────────────────────
+export function computeRepresentativeness(
+  matrix: ResponseMatrix,
+  labels: number[],
+): RepresentativenessRow[] {
+  const { values, questionIds } = matrix;
+  const clusters = [...new Set(labels)].sort((a, b) => a - b);
+
+  const rows: RepresentativenessRow[] = [];
+  for (const c of clusters) {
+    const inIdx = labels.flatMap((l, i) => (l === c ? [i] : []));
+    const outIdx = labels.flatMap((l, i) => (l !== c ? [i] : []));
+    for (let j = 0; j < questionIds.length; j++) {
+      const inVals = inIdx.map((i) => values[i][j]);
+      const outVals = outIdx.map((i) => values[i][j]);
+      const meanIn = inVals.length
+        ? inVals.reduce((s, v) => s + v, 0) / inVals.length
+        : 0;
+      const meanOut = outVals.length
+        ? outVals.reduce((s, v) => s + v, 0) / outVals.length
+        : 0;
+      const diff = meanIn - meanOut;
+      // 代表性スコア = |diff| を使用（Polisの比率検定の代替として単純化）
+      rows.push({
+        cluster_id: c,
+        question_id: questionIds[j],
+        mean_in: meanIn,
+        mean_out: meanOut,
+        diff,
+        representativeness: Math.abs(diff),
+      });
+    }
+  }
+  return rows;
+}
+
+// ────────────────────────────────────────────────────────────
+// 6. 質問ごとの dominant axis と disagreement (cluster間)
+// ────────────────────────────────────────────────────────────
+export interface QuestionAxisInfo {
+  question_id: string;
+  dominant_axis: "pc1" | "pc2";
+  disagreement_std: number; // クラスタ間平均値の標準偏差（合意/不合意度の指標）
+}
+
+export function computeQuestionAxes(
+  matrix: ResponseMatrix,
+  pcaResult: PCAResult,
+  labels: number[],
+): QuestionAxisInfo[] {
+  const { values, questionIds } = matrix;
+  const clusters = [...new Set(labels)].sort((a, b) => a - b);
+
+  return questionIds.map((qid, j) => {
+    const { pc1, pc2 } = pcaResult.loadingsByQuestion[qid];
+    const dominant: "pc1" | "pc2" =
+      Math.abs(pc1) >= Math.abs(pc2) ? "pc1" : "pc2";
+
+    // クラスタ間平均値の標準偏差
+    const clusterMeans = clusters.map((c) => {
+      const idx = labels.flatMap((l, i) => (l === c ? [i] : []));
+      if (idx.length === 0) return 0;
+      return idx.reduce((s, i) => s + values[i][j], 0) / idx.length;
+    });
+    const overallMean =
+      clusterMeans.reduce((s, v) => s + v, 0) / clusterMeans.length;
+    const variance =
+      clusterMeans.reduce((s, v) => s + (v - overallMean) ** 2, 0) /
+      clusterMeans.length;
+    const std = Math.sqrt(variance);
+
+    return { question_id: qid, dominant_axis: dominant, disagreement_std: std };
+  });
+}

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -34,6 +34,47 @@ export type Database = {
   }
   public: {
     Tables: {
+      answer_embeddings: {
+        Row: {
+          answer_id: string
+          created_at: string | null
+          embedding: string
+          id: string
+          model: string
+          question_id: string
+          session_id: string
+          text_hash: string
+        }
+        Insert: {
+          answer_id: string
+          created_at?: string | null
+          embedding: string
+          id?: string
+          model?: string
+          question_id: string
+          session_id: string
+          text_hash: string
+        }
+        Update: {
+          answer_id?: string
+          created_at?: string | null
+          embedding?: string
+          id?: string
+          model?: string
+          question_id?: string
+          session_id?: string
+          text_hash?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "answer_embeddings_answer_id_fkey"
+            columns: ["answer_id"]
+            isOneToOne: true
+            referencedRelation: "answers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       answers: {
         Row: {
           created_at: string | null
@@ -75,6 +116,187 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "sessions"
             referencedColumns: ["session_id"]
+          },
+        ]
+      }
+      cluster_assignments: {
+        Row: {
+          cluster_id: number
+          cluster_run_id: string
+          id: string
+          pc1: number
+          pc2: number
+          session_id: string
+        }
+        Insert: {
+          cluster_id: number
+          cluster_run_id: string
+          id?: string
+          pc1: number
+          pc2: number
+          session_id: string
+        }
+        Update: {
+          cluster_id?: number
+          cluster_run_id?: string
+          id?: string
+          pc1?: number
+          pc2?: number
+          session_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cluster_assignments_cluster_run_id_fkey"
+            columns: ["cluster_run_id"]
+            isOneToOne: false
+            referencedRelation: "cluster_runs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cluster_assignments_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "sessions"
+            referencedColumns: ["session_id"]
+          },
+        ]
+      }
+      cluster_insights: {
+        Row: {
+          cluster_run_id: string
+          created_at: string | null
+          disagreement_std: number | null
+          dominant_axis: string | null
+          id: string
+          insight_text: string | null
+          question_id: string
+        }
+        Insert: {
+          cluster_run_id: string
+          created_at?: string | null
+          disagreement_std?: number | null
+          dominant_axis?: string | null
+          id?: string
+          insight_text?: string | null
+          question_id: string
+        }
+        Update: {
+          cluster_run_id?: string
+          created_at?: string | null
+          disagreement_std?: number | null
+          dominant_axis?: string | null
+          id?: string
+          insight_text?: string | null
+          question_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cluster_insights_cluster_run_id_fkey"
+            columns: ["cluster_run_id"]
+            isOneToOne: false
+            referencedRelation: "cluster_runs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      cluster_runs: {
+        Row: {
+          axis_labels: Json | null
+          calculated_at: string | null
+          id: string
+          k_chosen: number
+          n_questions: number
+          n_respondents: number
+          params: Json | null
+          pca_explained_variance: Json
+          pca_loadings: Json
+          question_ids: Json
+          reasons_built_at: string | null
+          silhouette_by_k: Json | null
+          silhouette_score: number | null
+        }
+        Insert: {
+          axis_labels?: Json | null
+          calculated_at?: string | null
+          id?: string
+          k_chosen: number
+          n_questions: number
+          n_respondents: number
+          params?: Json | null
+          pca_explained_variance?: Json
+          pca_loadings?: Json
+          question_ids?: Json
+          reasons_built_at?: string | null
+          silhouette_by_k?: Json | null
+          silhouette_score?: number | null
+        }
+        Update: {
+          axis_labels?: Json | null
+          calculated_at?: string | null
+          id?: string
+          k_chosen?: number
+          n_questions?: number
+          n_respondents?: number
+          params?: Json | null
+          pca_explained_variance?: Json
+          pca_loadings?: Json
+          question_ids?: Json
+          reasons_built_at?: string | null
+          silhouette_by_k?: Json | null
+          silhouette_score?: number | null
+        }
+        Relationships: []
+      }
+      cluster_summaries: {
+        Row: {
+          cluster_id: number
+          cluster_run_id: string
+          created_at: string | null
+          diff: number | null
+          diversity_score: number | null
+          id: string
+          mean_in: number | null
+          mean_out: number | null
+          n_texts: number
+          question_id: string
+          representativeness: number | null
+          summary: string | null
+        }
+        Insert: {
+          cluster_id: number
+          cluster_run_id: string
+          created_at?: string | null
+          diff?: number | null
+          diversity_score?: number | null
+          id?: string
+          mean_in?: number | null
+          mean_out?: number | null
+          n_texts?: number
+          question_id: string
+          representativeness?: number | null
+          summary?: string | null
+        }
+        Update: {
+          cluster_id?: number
+          cluster_run_id?: string
+          created_at?: string | null
+          diff?: number | null
+          diversity_score?: number | null
+          id?: string
+          mean_in?: number | null
+          mean_out?: number | null
+          n_texts?: number
+          question_id?: string
+          representativeness?: number | null
+          summary?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cluster_summaries_cluster_run_id_fkey"
+            columns: ["cluster_run_id"]
+            isOneToOne: false
+            referencedRelation: "cluster_runs"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -303,3 +525,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -1,0 +1,157 @@
+// ============================================================
+// Embedding 取得: OpenRouter経由 (text-embedding-3-small, 1536次元)
+// 結果は answer_embeddings テーブルに永続化
+// ============================================================
+
+import {
+  callOpenRouterEmbedding,
+  EMBEDDING_DIM,
+  EMBEDDING_MODEL,
+} from "./openrouter";
+import { createAdminClient } from "./supabase";
+
+async function sha256(text: string): Promise<string> {
+  const encoded = new TextEncoder().encode(text);
+  const buf = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export interface AnswerForEmbedding {
+  answer_id: string;
+  session_id: string;
+  question_id: string;
+  text: string;
+}
+
+/**
+ * 与えられた answers (自由記述あり) を embedding化し、answer_embeddings に upsert する。
+ * text_hash で既存をスキップ。冪等。
+ */
+export async function ensureEmbeddings(
+  answers: AnswerForEmbedding[],
+): Promise<Map<string, number[]>> {
+  const supabase = createAdminClient();
+  const result = new Map<string, number[]>(); // answer_id -> embedding
+
+  if (answers.length === 0) return result;
+
+  const hashed = await Promise.all(
+    answers.map(async (a) => ({ ...a, text_hash: await sha256(a.text) })),
+  );
+
+  // 既存 embedding を一括取得
+  const answerIds = hashed.map((a) => a.answer_id);
+  const { data: existing } = await supabase
+    .from("answer_embeddings")
+    .select("answer_id, text_hash, embedding")
+    .in("answer_id", answerIds);
+
+  const existingByAnswer = new Map<
+    string,
+    { text_hash: string; embedding: number[] | string }
+  >();
+  for (const row of existing ?? []) {
+    existingByAnswer.set(row.answer_id, {
+      text_hash: row.text_hash,
+      embedding: row.embedding as unknown as number[] | string,
+    });
+  }
+
+  // 同じテキストに対するAPI呼び出しを重複させないキャッシュ
+  const hashToEmbedding = new Map<string, number[]>();
+  for (const e of existingByAnswer.values()) {
+    const emb = parseEmbedding(e.embedding);
+    if (emb) hashToEmbedding.set(e.text_hash, emb);
+  }
+
+  const toUpsert: Array<{
+    answer_id: string;
+    session_id: string;
+    question_id: string;
+    text_hash: string;
+    embedding: string;
+    model: string;
+  }> = [];
+
+  for (const a of hashed) {
+    const existingRow = existingByAnswer.get(a.answer_id);
+    if (existingRow && existingRow.text_hash === a.text_hash) {
+      const emb = parseEmbedding(existingRow.embedding);
+      if (emb) {
+        result.set(a.answer_id, emb);
+        continue;
+      }
+    }
+
+    let emb = hashToEmbedding.get(a.text_hash);
+    if (!emb) {
+      emb = await callOpenRouterEmbedding(a.text);
+      hashToEmbedding.set(a.text_hash, emb);
+    }
+    result.set(a.answer_id, emb);
+    toUpsert.push({
+      answer_id: a.answer_id,
+      session_id: a.session_id,
+      question_id: a.question_id,
+      text_hash: a.text_hash,
+      embedding: `[${emb.join(",")}]`,
+      model: EMBEDDING_MODEL,
+    });
+  }
+
+  if (toUpsert.length > 0) {
+    const { error } = await supabase
+      .from("answer_embeddings")
+      .upsert(toUpsert as never, { onConflict: "answer_id" });
+    if (error) console.error("answer_embeddings upsert failed:", error);
+  }
+
+  return result;
+}
+
+function parseEmbedding(
+  value: number[] | string | null | undefined,
+): number[] | null {
+  if (!value) return null;
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string") {
+    const trimmed = value.replace(/^\[/, "").replace(/\]$/, "");
+    if (!trimmed) return null;
+    const arr = trimmed.split(",").map(Number);
+    if (arr.some(Number.isNaN)) return null;
+    return arr;
+  }
+  return null;
+}
+
+export function cosineDistance(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 1;
+  return 1 - dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+export function meanPairwiseCosineDistance(
+  embeddings: number[][],
+): number | null {
+  if (embeddings.length < 2) return null;
+  let sum = 0;
+  let n = 0;
+  for (let i = 0; i < embeddings.length; i++) {
+    for (let j = i + 1; j < embeddings.length; j++) {
+      sum += cosineDistance(embeddings[i], embeddings[j]);
+      n++;
+    }
+  }
+  return n === 0 ? null : sum / n;
+}
+
+export { EMBEDDING_DIM, EMBEDDING_MODEL };

--- a/src/lib/likert.ts
+++ b/src/lib/likert.ts
@@ -1,0 +1,21 @@
+// ============================================================
+// リッカート尺度 ⇄ 数値スコア変換
+// Issue #26 共通ユーティリティ
+// ============================================================
+
+export const LIKERT_TO_NUMERIC: Record<string, number | null> = {
+  strongly_agree: 2,
+  agree: 1,
+  neutral: 0,
+  disagree: -1,
+  strongly_disagree: -2,
+  dont_know: null,
+};
+
+export function numericFromLikert(
+  value: string | null | undefined,
+): number | null {
+  if (!value) return null;
+  if (!(value in LIKERT_TO_NUMERIC)) return null;
+  return LIKERT_TO_NUMERIC[value];
+}

--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -1,7 +1,10 @@
 import { getCachedResponse, setCachedResponse } from "./llm-cache";
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
+const OPENROUTER_EMBEDDING_URL = "https://openrouter.ai/api/v1/embeddings";
 const MODEL = "google/gemini-3-flash-preview";
+export const EMBEDDING_MODEL = "openai/text-embedding-3-small";
+export const EMBEDDING_DIM = 1536;
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -81,3 +84,44 @@ export const MODEL_INFO = {
   description:
     "Google の Gemini 3 Flash Preview モデルを OpenRouter 経由で使用しています。回答のヒント生成と、フォローアップ質問の生成に使用されます。",
 };
+
+/**
+ * OpenRouter経由で embedding を取得する（OpenAI互換 /v1/embeddings エンドポイント）。
+ */
+export async function callOpenRouterEmbedding(text: string): Promise<number[]> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENROUTER_API_KEY is not set");
+  }
+
+  const response = await fetch(OPENROUTER_EMBEDDING_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "HTTP-Referer":
+        process.env.NEXT_PUBLIC_SUPABASE_URL ||
+        "https://citizen-survey.vercel.app",
+      "X-Title": "Citizen Survey",
+    },
+    body: JSON.stringify({ model: EMBEDDING_MODEL, input: text }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `OpenRouter embedding error (${response.status}): ${errorText}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    data?: Array<{ embedding: number[] }>;
+  };
+  const emb = data.data?.[0]?.embedding;
+  if (!emb || emb.length !== EMBEDDING_DIM) {
+    throw new Error(
+      `Unexpected embedding response shape (dim=${emb?.length ?? "missing"})`,
+    );
+  }
+  return emb;
+}

--- a/supabase/migrations/20260516000000_add_clustering_tables.sql
+++ b/supabase/migrations/20260516000000_add_clustering_tables.sql
@@ -1,0 +1,128 @@
+-- ============================================================
+-- クラスタリング分析パイプライン用テーブル群
+-- Issue #26: PCA + kmeansによる意見空間のクラスタリング
+-- Issue #27: クラスター内の理由テキスト分析と要約
+-- ============================================================
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ============================================================
+-- cluster_runs: 1回の再計算ジョブの結果メタデータ
+-- ============================================================
+CREATE TABLE cluster_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  calculated_at TIMESTAMPTZ DEFAULT NOW(),
+  n_respondents INTEGER NOT NULL,
+  n_questions INTEGER NOT NULL,
+  k_chosen INTEGER NOT NULL,
+  silhouette_score DOUBLE PRECISION,
+  pca_explained_variance JSONB NOT NULL DEFAULT '[]'::jsonb,
+  pca_loadings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  axis_labels JSONB DEFAULT '{}'::jsonb,
+  silhouette_by_k JSONB DEFAULT '{}'::jsonb,
+  question_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+  params JSONB DEFAULT '{}'::jsonb,
+  reasons_built_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_cluster_runs_calculated_at ON cluster_runs(calculated_at DESC);
+
+-- ============================================================
+-- cluster_assignments: 各回答者のクラスタID + 2D座標
+-- ============================================================
+CREATE TABLE cluster_assignments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cluster_run_id UUID NOT NULL REFERENCES cluster_runs(id) ON DELETE CASCADE,
+  session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+  cluster_id INTEGER NOT NULL,
+  pc1 DOUBLE PRECISION NOT NULL,
+  pc2 DOUBLE PRECISION NOT NULL,
+  UNIQUE(cluster_run_id, session_id)
+);
+
+CREATE INDEX idx_cluster_assignments_run ON cluster_assignments(cluster_run_id);
+CREATE INDEX idx_cluster_assignments_session ON cluster_assignments(session_id);
+
+-- ============================================================
+-- cluster_summaries: (cluster_run_id, cluster_id, question_id) ごとの要約
+-- ============================================================
+CREATE TABLE cluster_summaries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cluster_run_id UUID NOT NULL REFERENCES cluster_runs(id) ON DELETE CASCADE,
+  cluster_id INTEGER NOT NULL,
+  question_id TEXT NOT NULL,
+  summary TEXT DEFAULT '',
+  diversity_score DOUBLE PRECISION,
+  n_texts INTEGER NOT NULL DEFAULT 0,
+  mean_in DOUBLE PRECISION,
+  mean_out DOUBLE PRECISION,
+  diff DOUBLE PRECISION,
+  representativeness DOUBLE PRECISION,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(cluster_run_id, cluster_id, question_id)
+);
+
+CREATE INDEX idx_cluster_summaries_run ON cluster_summaries(cluster_run_id);
+
+-- ============================================================
+-- cluster_insights: 質問ごとのクラスタ横断インサイト + 軸情報
+-- ============================================================
+CREATE TABLE cluster_insights (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cluster_run_id UUID NOT NULL REFERENCES cluster_runs(id) ON DELETE CASCADE,
+  question_id TEXT NOT NULL,
+  insight_text TEXT DEFAULT '',
+  dominant_axis TEXT CHECK (dominant_axis IN ('pc1', 'pc2')),
+  disagreement_std DOUBLE PRECISION,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(cluster_run_id, question_id)
+);
+
+CREATE INDEX idx_cluster_insights_run ON cluster_insights(cluster_run_id);
+
+-- ============================================================
+-- answer_embeddings: 自由記述のembedding永続化
+-- ============================================================
+CREATE TABLE answer_embeddings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  answer_id UUID NOT NULL REFERENCES answers(id) ON DELETE CASCADE,
+  session_id TEXT NOT NULL,
+  question_id TEXT NOT NULL,
+  text_hash TEXT NOT NULL,
+  embedding vector(1536) NOT NULL,
+  model TEXT NOT NULL DEFAULT 'text-embedding-3-small',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(answer_id)
+);
+
+CREATE INDEX idx_answer_embeddings_text_hash ON answer_embeddings(text_hash);
+CREATE INDEX idx_answer_embeddings_question ON answer_embeddings(question_id);
+
+-- ============================================================
+-- Row Level Security: 全テーブル service_role のみアクセス可
+-- ============================================================
+ALTER TABLE cluster_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cluster_assignments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cluster_summaries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE cluster_insights ENABLE ROW LEVEL SECURITY;
+ALTER TABLE answer_embeddings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access to cluster_runs" ON cluster_runs
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "Service role full access to cluster_assignments" ON cluster_assignments
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "Service role full access to cluster_summaries" ON cluster_summaries
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "Service role full access to cluster_insights" ON cluster_insights
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY "Service role full access to answer_embeddings" ON answer_embeddings
+  FOR ALL USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary

Page1リッカート回答に対してPCA + kmeansによる意見空間のクラスタリングを行い、クラスタごとの自由記述要約・質問別クラスタ横断インサイトをLLMで生成するadmin向けパイプラインを実装。

- **数値**: `ml-pca` + `ml-kmeans` + 自前シルエットで K=2..6 から最良 K を自動選択
- **要約**: OpenRouter (Gemini) で各 (cluster × question) を100字要約 + embedding 平均cosine距離による多様性スコア
- **インサイト**: 回答分布 / 多様性 / 自由記述要約をまとめて LLM に渡し、全質問で300字程度のクラスタ横断分析を生成
- **軸ラベル**: PC1/PC2 の両極を LLM に命名させて admin UI に表示
- **API**: `POST /api/admin/cluster/recompute` / `POST /api/admin/cluster/build-reasons` / `GET /api/admin/cluster/latest`
- **UI**: admin に「クラスター分析」タブを追加。散布図・質問リスト・軸ラベル・insight・クラスタ別要約の極性比較ペイン・JSONダウンロード
- **DB**: `cluster_runs` / `cluster_assignments` / `cluster_summaries` / `cluster_insights` / `answer_embeddings` (`pgvector`) を新設
- **テストデータ**: `scripts/seed-cluster-test-data.ts` で4ペルソナ × 30回答 + フォローアップ5問を投入 (`pnpm seed:cluster`)
- **embedding**: OpenRouter 経由 `text-embedding-3-small` (1536次元)

## Test plan

- [ ] `supabase db reset` で新マイグレーションが適用される
- [ ] `pnpm seed:cluster` で30回答が投入される (冪等)
- [ ] `/admin` → クラスター分析タブ → 「再計算」で PCA + k-means が走り散布図が表示される
- [ ] 「理由を要約」で embedding取得 + クラスタ別要約 + 質問別 insight + PC1/PC2 軸ラベルが生成される
- [ ] 質問リストから設問を選ぶと insight (黄バナー) と PC+/PC- 側に分割された要約が表示される
- [ ] 「JSONダウンロード」で run / assignments / summaries / insights を含む JSON がダウンロードできる
- [ ] type-check (`npx tsc --noEmit`) が通る
- [ ] ビルド (`pnpm build`) が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)